### PR TITLE
Fix to support gradle forkEvery property and parallel tests execution

### DIFF
--- a/instrumentation/src/instrumentation/Instrumentator.java
+++ b/instrumentation/src/instrumentation/Instrumentator.java
@@ -19,7 +19,6 @@ package com.intellij.rt.coverage.instrumentation;
 import com.intellij.rt.coverage.data.ProjectData;
 import com.intellij.rt.coverage.util.ClassNameUtil;
 import com.intellij.rt.coverage.util.ErrorReporter;
-import com.intellij.rt.coverage.util.ProjectDataLoader;
 import com.intellij.rt.coverage.util.classFinder.ClassFinder;
 import org.jetbrains.org.objectweb.asm.ClassReader;
 import org.jetbrains.org.objectweb.asm.ClassVisitor;
@@ -59,9 +58,7 @@ public class Instrumentator {
     final File dataFile = new File(args[0]);
     final boolean calcUnloaded = Boolean.valueOf(args[2]).booleanValue();
     ProjectData initialData = null;
-    if (Boolean.valueOf(args[3]).booleanValue() && dataFile.isFile()) {
-      initialData = ProjectDataLoader.load(dataFile);
-    }
+    final boolean mergeData = Boolean.valueOf(args[3]).booleanValue();
     int i = 5;
 
     final File sourceMapFile;
@@ -108,7 +105,7 @@ public class Instrumentator {
     }
 
     final ClassFinder cf = new ClassFinder(includePatterns, excludePatterns);
-    final SaveHook hook = new SaveHook(dataFile, calcUnloaded, cf);
+    final SaveHook hook = new SaveHook(dataFile, calcUnloaded, cf, mergeData);
     hook.setSourceMapFile(sourceMapFile);
     Runtime.getRuntime().addShutdownHook(new Thread(hook));
 

--- a/instrumentation/src/instrumentation/SaveHook.java
+++ b/instrumentation/src/instrumentation/SaveHook.java
@@ -40,11 +40,13 @@ public class SaveHook implements Runnable {
     private File mySourceMapFile;
     private final boolean myAppendUnloaded;
     private final ClassFinder myClassFinder;
+    private final boolean myMergeFile;
 
-    public SaveHook(File dataFile, boolean appendUnloaded, ClassFinder classFinder) {
+    public SaveHook(File dataFile, boolean appendUnloaded, ClassFinder classFinder, boolean mergeFile) {
         myDataFile = dataFile;
         myAppendUnloaded = appendUnloaded;
         myClassFinder = classFinder;
+        myMergeFile = mergeFile;
     }
 
     public void run() {
@@ -58,6 +60,11 @@ public class SaveHook implements Runnable {
             lock = CoverageIOUtil.FileLock.lock(myDataFile);
             if (myAppendUnloaded) {
                 appendUnloaded(projectData);
+            }
+
+            if (myMergeFile) {
+                final ProjectData load = ProjectDataLoader.load(myDataFile);
+                projectData.merge(load);
             }
 
             DataOutputStream os = null;

--- a/src/com/intellij/rt/coverage/util/CoverageIOUtil.java
+++ b/src/com/intellij/rt/coverage/util/CoverageIOUtil.java
@@ -78,7 +78,7 @@ public class CoverageIOUtil {
      */
     public synchronized static FileLock lock(final File targetFile, final long totalTimeout, final TimeUnit unit, final long waitTimeMS) {
       final FileLock lock = new FileLock(targetFile);
-      for (int i = 0; i < unit.toMillis(totalTimeout); ++i) {
+      for (long timePassed = 0; timePassed < unit.toMillis(totalTimeout); ++timePassed) {
         if (lock.tryLock()) {
           return lock;
         }
@@ -99,7 +99,7 @@ public class CoverageIOUtil {
       if (lock == null) {
         return true;
       }
-      for (long i = 0; i < unit.toMillis(totalTimeout); i += waitTimeMS) {
+      for (long timePassed = 0; timePassed < unit.toMillis(totalTimeout); timePassed += waitTimeMS) {
         if (lock.tryUnlock()) {
           return true;
         }

--- a/util/src/util/ProjectDataLoader.java
+++ b/util/src/util/ProjectDataLoader.java
@@ -29,12 +29,20 @@ import java.io.*;
  */
 public class ProjectDataLoader {
 
-  public static ProjectData load(File sessionDataFile) throws InterruptedException {
-    final ProjectData projectInfo = new ProjectData();
-    DataInputStream in = null;
+  public static ProjectData loadLocked(final File sessionDataFile) {
     CoverageIOUtil.FileLock lock = null;
     try {
       lock = CoverageIOUtil.FileLock.lock(sessionDataFile);
+      return load(sessionDataFile);
+    } finally {
+      CoverageIOUtil.FileLock.unlock(lock);
+    }
+  }
+
+  public static ProjectData load(File sessionDataFile) {
+    final ProjectData projectInfo = new ProjectData();
+    DataInputStream in = null;
+    try {
       if (sessionDataFile.length() == 0) {
         return projectInfo;
       }
@@ -97,7 +105,6 @@ public class ProjectDataLoader {
       ErrorReporter.reportError("Failed to load coverage data from file: " + sessionDataFile.getAbsolutePath(), e);
       return projectInfo;
     } finally {
-      CoverageIOUtil.FileLock.unlock(lock);
       if (in != null) {
         try {
           in.close();


### PR DESCRIPTION
Currently running tests in TeamCity with gradle with forkEvery property set to positive number (recreate the VM each N tests) with IDEA Coverage is failing with EOFException [(issue on YT)](https://youtrack.jetbrains.com/issue/TW-36123) due to result files corruption caused by 2 issues in IDEA Coverage: 
1. If a new VM will be started before old is finished saving the data the coverage.ic file will be corrupted. The same problem occurs when there are 2 parallel VMs running tests. 
2. The old data is merged at the Agent initialization. In the parallel VMs case data from one of them would be lost. 

I've added a simple FileLock based on a temporary file. It's aqcuired before merging data from disk and writing data. 
