### PR TITLE
Fix gradle javadoc command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ dependencies {
   compile project(':util')
 }
 
+javadoc {
+  options.tags = [ "noinspection" ]
+}
+
 //noinspection GrUnresolvedAccess
 task wrapper(type: Wrapper) {
   gradleVersion = '4.5'

--- a/test-discovery/src/com/intellij/rt/coverage/testDiscovery/instrumentation/TestDiscoveryInstrumenter.java
+++ b/test-discovery/src/com/intellij/rt/coverage/testDiscovery/instrumentation/TestDiscoveryInstrumenter.java
@@ -128,7 +128,7 @@ public class TestDiscoveryInstrumenter extends ClassVisitor {
    * Insert call to the __$initMethodsVisited$__
    *
    * It also will create a method for interfaces which were skipped by default: for java 1.8- static methods in interfaces were not possible,
-   * but if there is non-<clinit> code in the interface, then it must be 1.8+
+   * but if there is non-&lt;clinit&gt; code in the interface, then it must be 1.8+
    */
   protected void ensureArrayInitialized(MethodVisitor mv) {
     if (myInterface && !myCreatedMethod) { //java 1.8 + can create static method


### PR DESCRIPTION
`./gradlew javadoc` was failing due to "noinspection" tags not being recognised, and because `<` and `>` should be escaped as `&lt;` and `&gt;`.