### PR TITLE
Filter out coverage of generated call from implementer to default interface method

### DIFF
--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/visiting/KotlinImplementerDefaultInterfaceMemberFilter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/visiting/KotlinImplementerDefaultInterfaceMemberFilter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.instrumentation.filters.visiting;
+
+import com.intellij.rt.coverage.data.LineData;
+import com.intellij.rt.coverage.instrumentation.Instrumenter;
+import com.intellij.rt.coverage.instrumentation.kotlin.KotlinUtils;
+import org.jetbrains.coverage.org.objectweb.asm.Label;
+import org.jetbrains.coverage.org.objectweb.asm.Opcodes;
+
+/**
+ * Default interface member should be filtered out from implementer.
+ * Instructions list of such method consists exactly of:
+ * <ol>
+ * <li>LABEL</li>
+ * <li>LINENUMBER</li>
+ * <li>ALOAD 0</li>
+ * <li>INVOKESTATIC to INTERFACE_NAME$DefaultImpls.INTERFACE_MEMBER</li>
+ * <li>RETURN</li>
+ * <li>LABEL</li>
+ * </ol>
+ * A method is filtered out is it's instructions list matches this structure.
+ */
+public class KotlinImplementerDefaultInterfaceMemberFilter extends MethodVisitingFilter {
+  private byte matchedInstructions = 0;
+  private int myLine = -1;
+  private LineData myPreviousLineData;
+
+  @Override
+  public boolean isApplicable(Instrumenter context) {
+    return KotlinUtils.isKotlinClass(context) && context.hasInterfaces();
+  }
+
+  protected void filter() {
+    if (myPreviousLineData == null) {
+      myContext.removeLine(myLine);
+    }
+  }
+
+  @Override
+  public void visitLabel(Label label) {
+    super.visitLabel(label);
+    if (completed()) return;
+    if (matchedInstructions == 0) {
+      matchedInstructions = 1;
+    } else if (matchedInstructions == 5) {
+      myState = State.SHOULD_NOT_COVER;
+    } else {
+      myState = State.SHOULD_COVER;
+    }
+  }
+
+  @Override
+  public void visitLineNumber(int line, Label start) {
+    myPreviousLineData = myContext.getLineData(line);
+    super.visitLineNumber(line, start);
+    if (completed()) return;
+    if (matchedInstructions == 1) {
+      matchedInstructions = 2;
+      myLine = line;
+    } else {
+      myState = State.SHOULD_COVER;
+    }
+  }
+
+  @Override
+  public void visitVarInsn(int opcode, int var) {
+    super.visitVarInsn(opcode, var);
+    if (completed()) return;
+    if (matchedInstructions == 2 && opcode == Opcodes.ALOAD && var == 0) {
+      matchedInstructions = 3;
+    } else {
+      myState = State.SHOULD_COVER;
+    }
+  }
+
+  @Override
+  public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+    super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+    if (completed()) return;
+    if (matchedInstructions == 3 && owner.endsWith("$DefaultImpls")) {
+      matchedInstructions = 4;
+    } else {
+      myState = State.SHOULD_COVER;
+    }
+  }
+
+  @Override
+  public void visitInsn(int opcode) {
+    super.visitInsn(opcode);
+    if (completed()) return;
+    if (matchedInstructions == 4 && opcode == Opcodes.RETURN) {
+      matchedInstructions = 5;
+    } else {
+      myState = State.SHOULD_COVER;
+    }
+  }
+}

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/visiting/MethodVisitingFilter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/visiting/MethodVisitingFilter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.instrumentation.filters.visiting;
+
+import com.intellij.rt.coverage.instrumentation.Instrumenter;
+import org.jetbrains.coverage.org.objectweb.asm.MethodVisitor;
+import org.jetbrains.coverage.org.objectweb.asm.Opcodes;
+
+/**
+ * Filters out coverage from method if matches filter.
+ */
+public abstract class MethodVisitingFilter extends MethodVisitor {
+
+  protected abstract void filter();
+
+  protected enum State {
+    SHOULD_COVER, SHOULD_NOT_COVER, UNKNOWN
+  }
+
+  protected Instrumenter myContext;
+  protected State myState;
+
+  public MethodVisitingFilter() {
+    super(Opcodes.API_VERSION);
+  }
+
+  public void initFilter(MethodVisitor methodVisitor, Instrumenter context) {
+    mv = methodVisitor;
+    myContext = context;
+    myState = State.UNKNOWN;
+  }
+
+  public abstract boolean isApplicable(Instrumenter context);
+
+  protected boolean completed() {
+    return myState != State.UNKNOWN;
+  }
+
+  @Override
+  public void visitEnd() {
+    super.visitEnd();
+    if (myState == State.SHOULD_NOT_COVER) {
+      filter();
+    }
+  }
+}

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/kotlin/KotlinUtils.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/kotlin/KotlinUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.instrumentation.kotlin;
+
+import com.intellij.rt.coverage.instrumentation.Instrumenter;
+
+public class KotlinUtils {
+  private static final String KOTLIN_CLASS_LABEL = "IS_KOTLIN";
+
+  public static boolean isKotlinClass(Instrumenter context) {
+    Object currentProperty = context.getProperty(KOTLIN_CLASS_LABEL);
+    if (currentProperty instanceof Boolean) return (Boolean) currentProperty;
+    boolean isKotlin = context.getAnnotations().contains("Lkotlin/Metadata;");
+    context.addProperty(KOTLIN_CLASS_LABEL, isKotlin);
+    return isKotlin;
+  }
+}

--- a/test-kotlin/build.gradle
+++ b/test-kotlin/build.gradle
@@ -11,6 +11,9 @@ sourceSets {
     test.java.srcDirs = [file('src')]
 }
 
+targetCompatibility = "1.8"
+sourceCompatibility = "1.8"
+
 dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 

--- a/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
@@ -76,13 +76,25 @@ class KotlinCoverageStatusTest {
     fun testDataClass() = test("dataClass", "kotlinTestData.dataClass.A")
 
     @Test
+    fun testDefaultInterfaceMember() = test("defaultInterfaceMember", "kotlinTestData.defaultInterfaceMember.Foo\$DefaultImpls", "kotlinTestData.defaultInterfaceMember.Bar")
+
+    @Test
+    fun testDefaultInterfaceMemberRemoveOnlyInterfaceMember() = test("defaultInterfaceMember.removeOnlyDefaultInterfaceMember", "kotlinTestData.defaultInterfaceMember.removeOnlyDefaultInterfaceMember.Bar")
+
+    @Test
+    fun testDefaultInterfaceMemberJava() = test("defaultInterfaceMember.java",
+            "kotlinTestData.defaultInterfaceMember.java.Foo", "kotlinTestData.defaultInterfaceMember.java.Bar",
+            fileName = "Test.java")
+
+    @Test
     fun testImplementationByDelegation() = test("implementationByDelegation", "kotlinTestData.implementationByDelegation.Derived")
 
     @Test
     fun testImplementationByDelegationGeneric() = test("implementationByDelegationGeneric", "kotlinTestData.implementationByDelegationGeneric.BDelegation")
 
-    private fun test(testName: String, vararg classes: String = arrayOf("kotlinTestData.$testName.TestKt"), sampling: Boolean = true) {
-        val testFile = pathToFile("src", "kotlinTestData", *testName.split('.').toTypedArray(), "test.kt")
+    private fun test(testName: String, vararg classes: String = arrayOf("kotlinTestData.$testName.TestKt"),
+                     sampling: Boolean = true, fileName: String = "test.kt") {
+        val testFile = pathToFile("src", "kotlinTestData", *testName.split('.').toTypedArray(), fileName)
         val expected = extractCoverageDataFromFile(testFile)
         val project = runWithCoverage(myDataFile, testName, sampling)
         assertEqualsLines(project, expected, classes.toList())

--- a/test-kotlin/src/kotlinTestData/defaultInterfaceMember/java/Test.java
+++ b/test-kotlin/src/kotlinTestData/defaultInterfaceMember/java/Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.defaultInterfaceMember.java;
+
+public class Test {
+  public static void main(String[] args) {
+    new Bar().foo2();
+  }
+}
+
+
+interface Foo {
+  default void foo1() {
+  }                           // coverage: NONE
+
+  default void foo2() {
+  }                           // coverage: FULL
+
+  default void foo3() {
+  }                           // coverage: NONE
+}
+
+class Bar implements Foo {
+  public Bar() { }            // coverage: FULL
+
+  @Override
+  public void foo1() {
+  }                           // coverage: NONE
+
+}

--- a/test-kotlin/src/kotlinTestData/defaultInterfaceMember/removeOnlyDefaultInterfaceMember/test.kt
+++ b/test-kotlin/src/kotlinTestData/defaultInterfaceMember/removeOnlyDefaultInterfaceMember/test.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.defaultInterfaceMember.removeOnlyDefaultInterfaceMember
+
+interface Foo {
+    fun foo1() {
+        return
+    }
+}
+
+class Bar() : Foo {           // coverage: FULL , constructor is here
+}
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        Bar()
+    }
+}

--- a/test-kotlin/src/kotlinTestData/defaultInterfaceMember/test.kt
+++ b/test-kotlin/src/kotlinTestData/defaultInterfaceMember/test.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.defaultInterfaceMember
+
+interface Foo {
+    fun foo1() {
+        return                // coverage: NONE
+    }
+    fun foo2() {
+        return                // coverage: FULL
+    }
+    fun foo3() {
+        return                // coverage: NONE
+    }
+}
+
+class Bar                     // line is invisible for coverage as default member is covered in Foo
+() : Foo {                    // coverage: FULL
+    override fun foo1() {
+        return                // coverage: NONE
+    }
+}
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        Bar().foo2()
+    }
+}


### PR DESCRIPTION
Here a Filter has no access to instructions list because instrumenting visitors do not extend MethodNode, as it causes more memory and time consumption. Therefore, filters have to decide whether to filter while visiting. 
Note: it seems like an overhead of visitor calls when there are too many Filters(I think it's not the case).
Note2: filtered lines are ignored, but extra instrumentation is added anyway
Note3: ClassInstrumenter already extends MethodNode