### PR TITLE
Filter when mapping default branch

### DIFF
--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/LineEnumerator.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/LineEnumerator.java
@@ -21,7 +21,6 @@ import com.intellij.rt.coverage.util.ClassNameUtil;
 import org.jetbrains.coverage.org.objectweb.asm.Label;
 import org.jetbrains.coverage.org.objectweb.asm.MethodVisitor;
 import org.jetbrains.coverage.org.objectweb.asm.Opcodes;
-import org.jetbrains.coverage.org.objectweb.asm.tree.LabelNode;
 import org.jetbrains.coverage.org.objectweb.asm.tree.MethodNode;
 
 import java.util.HashMap;
@@ -72,7 +71,7 @@ public class LineEnumerator extends MethodVisitor implements Opcodes {
                         final String desc,
                         final String signature,
                         final String[] exceptions) {
-    super(Opcodes.API_VERSION, new MethodNode(access, name, desc, signature, exceptions));
+    super(Opcodes.API_VERSION, new SaveLabelsMethodNode(access, name, desc, signature, exceptions));
     myClassInstrumenter = classInstrumenter;
     myWriterMethodVisitor = mv;
     myAccess = access;
@@ -114,9 +113,6 @@ public class LineEnumerator extends MethodVisitor implements Opcodes {
     }
     if (opcode != Opcodes.GOTO && opcode != Opcodes.JSR && !myMethodName.equals("<clinit>")) {
       if (myJumps == null) myJumps = new HashSet<Label>();
-      if (label.info == null) {
-        label.info = new LabelNode(label);
-      }
       myJumps.add(label);
       myLastJump = label;
       final LineData lineData = myClassInstrumenter.getLineData(myCurrentLine);

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/SaveLabelsMethodNode.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/SaveLabelsMethodNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.instrumentation;
+
+import org.jetbrains.coverage.org.objectweb.asm.Label;
+import org.jetbrains.coverage.org.objectweb.asm.Opcodes;
+import org.jetbrains.coverage.org.objectweb.asm.tree.LabelNode;
+import org.jetbrains.coverage.org.objectweb.asm.tree.MethodNode;
+
+/** With this MethodNode implementation MethodNode and a class using it work with the same Labels. */
+public class SaveLabelsMethodNode extends MethodNode {
+  public SaveLabelsMethodNode(int access, String name, String desc, String signature, String[] exceptions) {
+    super(Opcodes.API_VERSION, access, name, desc, signature, exceptions);
+  }
+
+  /**
+   *  Unlike super implementation here label is set to new LabelNode, so new Label will not be created.
+   */
+  @Override
+  protected LabelNode getLabelNode(Label label) {
+    if (!(label.info instanceof LabelNode)) {
+      label.info = new LabelNode(label);
+    }
+    return (LabelNode)label.info;
+  }
+}

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/enumerating/KotlinWhenMappingExceptionFilter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/enumerating/KotlinWhenMappingExceptionFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.instrumentation.filters.enumerating;
+
+import com.intellij.rt.coverage.data.SwitchData;
+import com.intellij.rt.coverage.instrumentation.Instrumenter;
+import com.intellij.rt.coverage.instrumentation.kotlin.KotlinUtils;
+import org.jetbrains.coverage.org.objectweb.asm.Label;
+import org.jetbrains.coverage.org.objectweb.asm.Opcodes;
+
+public class KotlinWhenMappingExceptionFilter extends LineEnumeratorFilter {
+
+  private Label myCurrentLabel = null;
+
+  @Override
+  public boolean isApplicable(Instrumenter context, int access, String name, String desc, String signature, String[] exceptions) {
+    return KotlinUtils.isKotlinClass(context);
+  }
+
+  @Override
+  public void visitLabel(Label label) {
+    super.visitLabel(label);
+    myCurrentLabel = label;
+  }
+
+  @Override
+  public void visitTypeInsn(int opcode, String type) {
+    super.visitTypeInsn(opcode, type);
+    if (opcode == Opcodes.NEW && type.equals("kotlin/NoWhenBranchMatchedException")) {
+      SwitchData switchData = myContext.getSwitchLabels().get(myCurrentLabel);
+      if (switchData != null) {
+        switchData.touch(-1);
+      }
+    }
+  }
+}

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/enumerating/LineEnumeratorFilter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/enumerating/LineEnumeratorFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.instrumentation.filters.enumerating;
+
+import com.intellij.rt.coverage.instrumentation.Instrumenter;
+import com.intellij.rt.coverage.instrumentation.LineEnumerator;
+import org.jetbrains.coverage.org.objectweb.asm.MethodVisitor;
+import org.jetbrains.coverage.org.objectweb.asm.Opcodes;
+
+public abstract class LineEnumeratorFilter extends MethodVisitor {
+  protected LineEnumerator myContext;
+
+  public LineEnumeratorFilter() {
+    super(Opcodes.API_VERSION);
+  }
+
+  public abstract boolean isApplicable(Instrumenter context, int access, String name,
+                                       String desc, String signature, String[] exceptions);
+
+  public void initFilter(MethodVisitor mv, LineEnumerator context) {
+    this.mv = mv;
+    myContext = context;
+  }
+}

--- a/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
@@ -93,6 +93,12 @@ class KotlinCoverageStatusTest {
     fun testImplementationByDelegationGeneric() = test("implementationByDelegationGeneric", "kotlinTestData.implementationByDelegationGeneric.BDelegation")
 
     @Test
+    fun testWhenMappingsSampling() = test("whenMapping.sampling")
+
+    @Test
+    fun testWhenMappingTracing() = test("whenMapping.tracing", sampling = false)
+
+    @Test
     fun testJavaSwitch() = test("javaSwitch", "kotlinTestData.javaSwitch.JavaSwitchTest", sampling = false, fileName = "JavaSwitchTest.java")
 
     @Test

--- a/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
@@ -93,6 +93,9 @@ class KotlinCoverageStatusTest {
     fun testImplementationByDelegationGeneric() = test("implementationByDelegationGeneric", "kotlinTestData.implementationByDelegationGeneric.BDelegation")
 
     @Test
+    fun testJavaSwitch() = test("javaSwitch", "kotlinTestData.javaSwitch.JavaSwitchTest", sampling = false, fileName = "JavaSwitchTest.java")
+
+    @Test
     fun testSealedClassConstructor() = test("sealedClassConstructor",
             "kotlinTestData.sealedClassConstructor.SealedClass",
             "kotlinTestData.sealedClassConstructor.SealedClassWithArgs",

--- a/test-kotlin/src/kotlinTestData/javaSwitch/JavaSwitchTest.java
+++ b/test-kotlin/src/kotlinTestData/javaSwitch/JavaSwitchTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.javaSwitch;
+
+public class JavaSwitchTest { // coverage: NONE
+  static int f(int x) {
+    switch (x) {              // coverage: FULL
+      case 1: return 42;      // coverage: FULL
+      case 2: return 43;      // coverage: FULL
+      default: return 52;     // coverage: FULL
+    }
+  }
+}

--- a/test-kotlin/src/kotlinTestData/javaSwitch/test.kt
+++ b/test-kotlin/src/kotlinTestData/javaSwitch/test.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.javaSwitch
+
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        JavaSwitchTest.f(1)
+        JavaSwitchTest.f(2)
+        JavaSwitchTest.f(3)
+    }
+}

--- a/test-kotlin/src/kotlinTestData/whenMapping/sampling/test.kt
+++ b/test-kotlin/src/kotlinTestData/whenMapping/sampling/test.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.whenMapping.sampling
+
+enum class F {
+    A, B, C
+}
+
+fun f(f: F): Int {
+    return when (f) {    // coverage: FULL
+        F.A, F.B -> 42   // coverage: FULL
+        F.C -> 36        // coverage: NONE
+    }
+}
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        f(F.A)
+        return
+    }
+}

--- a/test-kotlin/src/kotlinTestData/whenMapping/tracing/test.kt
+++ b/test-kotlin/src/kotlinTestData/whenMapping/tracing/test.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.whenMapping.tracing
+
+enum class F {
+    A, B, C
+}
+
+fun f(f: F): Int {
+    return when (f) {                   // coverage: PARTIAL as branch 2 not covered
+        F.A, F.B -> 42                  // coverage: FULL
+        F.C -> 36                       // coverage: NONE
+    }
+}
+
+enum class SimpleEnum {
+    Single
+}
+
+fun simpleF(v: SimpleEnum) =
+        when (v) {                      // coverage: FULL as no branching for else
+            SimpleEnum.Single -> 42     // coverage: FULL
+        }                               // coverage: FULL as return is here
+
+fun noneF(v: SimpleEnum) =
+        when (v) {                      // coverage: NONE
+            SimpleEnum.Single -> 42     // coverage: NONE
+        }                               // coverage: NONE
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        f(F.A)
+        simpleF(SimpleEnum.Single)
+        return
+    }
+}


### PR DESCRIPTION
1) Fixed switch coverage. There was a problem when MethodNode created new Labels, which differ from that we have already saved => switch labels were not covered => it was impossible to have full covered switch.
2) Implemented ignoring default branch in Kotlin when mapping. It is implemented by marking default branch always covered. This works Ok, because FULL and PARTIAL statuses are not affected, NONE status is possible because of check on line coverage [here](https://github.com/JetBrains/intellij-coverage/blob/0683b88e4ef52ae25fe02e8d74b817a4e1dfcd1e/src/com/intellij/rt/coverage/data/LineData.java#L59).
2a) I considered an implementation when default branch is fairly ignored, but it requires changes in coverage report format. 