### PR TITLE
Fix inline coverage

### DIFF
--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/Instrumenter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/Instrumenter.java
@@ -19,6 +19,7 @@ package com.intellij.rt.coverage.instrumentation;
 import com.intellij.rt.coverage.data.ClassData;
 import com.intellij.rt.coverage.data.LineData;
 import com.intellij.rt.coverage.data.ProjectData;
+import com.intellij.rt.coverage.instrumentation.filters.signature.KotlinSyntheticAccessMethodFilter;
 import com.intellij.rt.coverage.instrumentation.filters.signature.KotlinSyntheticConstructorOfSealedClassFilter;
 import com.intellij.rt.coverage.instrumentation.filters.signature.MethodSignatureFilter;
 import com.intellij.rt.coverage.instrumentation.filters.visiting.KotlinImplementerDefaultInterfaceMemberFilter;
@@ -80,7 +81,7 @@ public abstract class Instrumenter extends ClassVisitor {
       return mv;
     }
     for (MethodSignatureFilter filter : ourSignatureFilters) {
-      if (filter.shouldFilter(access, name, desc, signature, exceptions)) {
+      if (filter.shouldFilter(access, name, desc, signature, exceptions, this)) {
         return mv;
       }
     }
@@ -195,6 +196,7 @@ public abstract class Instrumenter extends ClassVisitor {
   private static List<MethodSignatureFilter> getMethodSignatureFilters() {
     List<MethodSignatureFilter> result = new ArrayList<MethodSignatureFilter>();
     result.add(new KotlinSyntheticConstructorOfSealedClassFilter());
+    result.add(new KotlinSyntheticAccessMethodFilter());
     return result;
   }
 }

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/signature/KotlinSyntheticAccessMethodFilter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/signature/KotlinSyntheticAccessMethodFilter.java
@@ -17,12 +17,13 @@
 package com.intellij.rt.coverage.instrumentation.filters.signature;
 
 import com.intellij.rt.coverage.instrumentation.Instrumenter;
+import com.intellij.rt.coverage.instrumentation.kotlin.KotlinUtils;
 import org.jetbrains.coverage.org.objectweb.asm.Opcodes;
 
-public class KotlinSyntheticConstructorOfSealedClassFilter implements MethodSignatureFilter {
+public class KotlinSyntheticAccessMethodFilter implements MethodSignatureFilter {
   public boolean shouldFilter(int access, String name, String desc, String signature, String[] exceptions, Instrumenter context) {
     return (access & Opcodes.ACC_SYNTHETIC) != 0
-        && name.equals("<init>")
-        && desc.endsWith("Lkotlin/jvm/internal/DefaultConstructorMarker;)V");
+        && KotlinUtils.isKotlinClass(context)
+        && name.startsWith("access$");
   }
 }

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/signature/MethodSignatureFilter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/signature/MethodSignatureFilter.java
@@ -16,9 +16,11 @@
 
 package com.intellij.rt.coverage.instrumentation.filters.signature;
 
+import com.intellij.rt.coverage.instrumentation.Instrumenter;
+
 /**
  * Filters out coverage from method if it's signature matches filter.
  */
 public interface MethodSignatureFilter {
-  boolean shouldFilter(int access, String name, String desc, String signature, String[] exceptions);
+  boolean shouldFilter(int access, String name, String desc, String signature, String[] exceptions, Instrumenter context);
 }

--- a/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
@@ -51,12 +51,23 @@ class KotlinCoverageStatusTest {
     fun testDefaultArgsSeveralArgs() = test("defaultArgs.severalArguments")
 
     @Test
-    @Ignore("Not implemented")
-    fun testInline() = test("inline")
+    fun testSimpleInline() = test("inline.simple")
 
     @Test
-    @Ignore("Not implemented")
-    fun testInlineInline() = test("inlineInline")
+    fun testInlineInline() = test("inline.inlineInline")
+
+    @Test
+    fun testLambdaInline() = test("inline.lambda")
+
+    @Test
+    fun testReflection() = test("inline.reflection", "kotlinTestData.inline.reflection.Test")
+
+    @Test
+    fun testReified() = test("inline.reified")
+
+    @Test
+    fun testMultiplyFilesInline() = test("inline.multiplyFiles", "kotlinTestData.inline.multiplyFiles.Test2Kt",
+            fileName = "test2.kt")
 
     @Test
     @Ignore("Not implemented")

--- a/test-kotlin/src/kotlinTestData/inline/inlineInline/test.kt
+++ b/test-kotlin/src/kotlinTestData/inline/inlineInline/test.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package kotlinTestData.inlineInline
+package kotlinTestData.inline.inlineInline
 
 private inline fun a() {
     print("Hello")         // coverage: FULL

--- a/test-kotlin/src/kotlinTestData/inline/lambda/test.kt
+++ b/test-kotlin/src/kotlinTestData/inline/lambda/test.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.inline.lambda
+
+import kotlin.random.Random
+
+
+private inline fun a(f: (Int) -> Unit, gen: () -> Int) {
+    val x = gen()                // coverage: FULL
+    print("Got x = ")            // coverage: FULL
+    f(x)                         // coverage: FULL
+    return                       // coverage: FULL
+}
+
+private inline fun c(f: (x: Int) -> Unit) {
+    a(f) {                       // coverage: FULL
+        Random.nextInt()         // coverage: FULL
+    }
+    return                       // coverage: FULL
+}
+
+private fun f() {
+    c {                          // coverage: FULL
+        println(it)              // coverage: FULL
+    }                            // coverage: FULL
+    return                       // coverage: FULL
+}
+
+private inline fun b(
+        list: List<Int>,
+        foo: (x: Int) -> Int
+) = list.map(foo)                // coverage: FULL
+
+fun test() {
+    b(listOf(3, 4)) {            // coverage: FULL
+        it + 45                  // coverage: FULL
+    }
+    f()                          // coverage: FULL
+    return                       // coverage: FULL
+}
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        test()
+    }
+}

--- a/test-kotlin/src/kotlinTestData/inline/multiplyFiles/test.kt
+++ b/test-kotlin/src/kotlinTestData/inline/multiplyFiles/test.kt
@@ -14,15 +14,23 @@
  * limitations under the License.
  */
 
-package com.intellij.rt.coverage.instrumentation.filters.signature;
+package kotlinTestData.inline.multiplyFiles
 
-import com.intellij.rt.coverage.instrumentation.Instrumenter;
-import org.jetbrains.coverage.org.objectweb.asm.Opcodes;
+private fun f() {
+    separateC {
+        println(it)
+    }
+    return
+}
 
-public class KotlinSyntheticConstructorOfSealedClassFilter implements MethodSignatureFilter {
-  public boolean shouldFilter(int access, String name, String desc, String signature, String[] exceptions, Instrumenter context) {
-    return (access & Opcodes.ACC_SYNTHETIC) != 0
-        && name.equals("<init>")
-        && desc.endsWith("Lkotlin/jvm/internal/DefaultConstructorMarker;)V");
-  }
+fun test() {
+    f()
+    return
+}
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        test()
+    }
 }

--- a/test-kotlin/src/kotlinTestData/inline/multiplyFiles/test2.kt
+++ b/test-kotlin/src/kotlinTestData/inline/multiplyFiles/test2.kt
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-package kotlinTestData.inline
+package kotlinTestData.inline.multiplyFiles
 
-private inline fun a(x: Int) {
-    println(x)                // coverage: FULL
-    return                    // coverage: FULL
+import kotlin.random.Random
+
+
+inline fun separateA(f: (Int) -> Unit, gen: () -> Int) {
+    val x = gen()                // coverage: FULL
+    print("Got x = ")            // coverage: FULL
+    f(x)                         // coverage: FULL
+    return                       // coverage: FULL
 }
 
-fun test() {
-    a(4)                      // coverage: FULL
-    return                    // coverage: FULL
-}
-
-object Test {
-    @JvmStatic
-    fun main(args: Array<String>) {
-        test()
+inline fun separateC(f: (x: Int) -> Unit) {
+    separateA(f) {               // coverage: FULL
+        Random.nextInt()         // coverage: FULL
     }
+    return                       // coverage: FULL
 }

--- a/test-kotlin/src/kotlinTestData/inline/reflection/test.kt
+++ b/test-kotlin/src/kotlinTestData/inline/reflection/test.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.inline.reflection
+
+object Test {                    // coverage: FULL
+    @JvmStatic
+    fun main(args: Array<String>) {
+        test()                   // coverage: FULL
+        return                   // coverage: FULL
+    }
+
+    inline fun a(x: Int) {
+        println(x)                // coverage: FULL
+        return                    // coverage: FULL
+    }
+
+    inline fun b(f: (Int) -> Int) {
+        println(f(4))             // coverage: FULL
+        return                    // coverage: FULL
+    }
+
+    fun test() {
+        this::class.java.getDeclaredMethod("a", Int::class.java).invoke(this, 42)   // coverage: FULL
+        val f =  { x: Int -> x + 42 }                                               // coverage: FULL
+        this::class.java.declaredMethods.single { it.name == "b" }.invoke(this, f)  // coverage: FULL
+        return                                                                      // coverage: FULL
+    }
+}

--- a/test-kotlin/src/kotlinTestData/inline/reified/test.kt
+++ b/test-kotlin/src/kotlinTestData/inline/reified/test.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.inline.reified
+
+inline fun <reified T> createArray(size: Int): Any = when (T::class) { // coverage: FULL
+    Int::class ->                                                      // coverage: FULL
+        IntArray(size)                                                 // coverage: FULL
+    Long::class ->                                                     // coverage: FULL
+        LongArray(size)                                                // coverage: NONE
+    else ->
+        Array<T?>(size) { null }                                       // coverage: FULL
+}                                                                      // coverage: FULL
+
+fun test() {
+    val a = createArray<Int>(10)                                      // coverage: FULL
+    val b = createArray<Any>(30)                                      // coverage: FULL
+}                                                                     // coverage: FULL
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        test()
+    }
+}

--- a/test-kotlin/src/kotlinTestData/inline/simple/test.kt
+++ b/test-kotlin/src/kotlinTestData/inline/simple/test.kt
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-package com.intellij.rt.coverage.instrumentation.filters.signature;
+package kotlinTestData.inline.simple
 
-import com.intellij.rt.coverage.instrumentation.Instrumenter;
-import org.jetbrains.coverage.org.objectweb.asm.Opcodes;
+private inline fun a(x: Int) {
+    println(x)                // coverage: FULL
+    return                    // coverage: FULL
+}
 
-public class KotlinSyntheticConstructorOfSealedClassFilter implements MethodSignatureFilter {
-  public boolean shouldFilter(int access, String name, String desc, String signature, String[] exceptions, Instrumenter context) {
-    return (access & Opcodes.ACC_SYNTHETIC) != 0
-        && name.equals("<init>")
-        && desc.endsWith("Lkotlin/jvm/internal/DefaultConstructorMarker;)V");
-  }
+fun test() {
+    a(4)                      // coverage: FULL
+    return                    // coverage: FULL
+}
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        test()
+    }
 }

--- a/test-kotlin/src/kotlinTestData/inline/simpleInline.kt
+++ b/test-kotlin/src/kotlinTestData/inline/simpleInline.kt
@@ -1,0 +1,4 @@
+package kotlinTestData.inline
+private fun a() = print("hello")
+private inline fun c() = a()
+fun b() = c()

--- a/tests/src/com/intellij/rt/coverage/SMAPParsingTest.java
+++ b/tests/src/com/intellij/rt/coverage/SMAPParsingTest.java
@@ -67,6 +67,26 @@ public class SMAPParsingTest extends TestCase {
       "9#1,6:17\n" +
       "*E";
 
+  /** test-kotlin/src/kotlinTestData/inline/simpleInline.kt */
+  private static final String KOTLIN_SMAP_WITH_INLINE2 = "SMAP\n" +
+      "simpleInline.kt\n" +
+      "Kotlin\n" +
+      "*S Kotlin\n" +
+      "*F\n" +
+      "+ 1 simpleInline.kt\n" +
+      "kotlinTestData/inline/SimpleInlineKt\n" +
+      "*L\n" +
+      "1#1,4:1\n" +
+      "3#1:5\n" +
+      "*E\n" +
+      "*S KotlinDebug\n" +
+      "*F\n" +
+      "+ 1 simpleInline.kt\n" +
+      "kotlinTestData/inline/SimpleInlineKt\n" +
+      "*L\n" +
+      "4#1:5\n" +
+      "*E";
+
   private static final String JSP_SMAP = "SMAP\n" +
       "Hello_jsp.java\n" +
       "JSP\n" +
@@ -100,6 +120,19 @@ public class SMAPParsingTest extends TestCase {
       "15#0,5:91\n" +
       "*E";
 
+  public void testJspSMAPKotlinInline() {
+    final FileMapData[] expected = new FileMapData[]{new FileMapData("kotlinTestData.inline.SimpleInlineKt",
+        new LineMapData[]{
+            new LineMapData(1, 1, 1),
+            new LineMapData(2, 2, 2),
+            new LineMapData(3, 3, 3),
+            new LineMapData(3, 5, 5),
+            new LineMapData(4, 4, 4)
+        })};
+    final FileMapData[] datas = JSR45Util.extractLineMapping(KOTLIN_SMAP_WITH_INLINE2, "kotlinTestData.inline.SimpleInlineKt");
+    testJspSmapData(expected, datas);
+  }
+
   public void testJspSMAP() {
     final FileMapData[] expected = new FileMapData[]{new FileMapData("org.apache.jsp.Hello_jsp",
         new LineMapData[]{
@@ -119,10 +152,14 @@ public class SMAPParsingTest extends TestCase {
                 new LineMapData(3, 66, 69)})};
 
     final FileMapData[] datas = JSR45Util.extractLineMapping(JSP_SMAP, "org.apache.jsp.Hello_jsp");
-    Assert.assertNotNull(datas);
-    Assert.assertEquals(expected.length, datas.length);
-    for (int i = 0; i < datas.length; i++) {
-      final FileMapData data = datas[i];
+    testJspSmapData(expected, datas);
+  }
+
+  private void testJspSmapData(FileMapData[] expected, FileMapData[] actual) {
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(expected.length, actual.length);
+    for (int i = 0; i < actual.length; i++) {
+      final FileMapData data = actual[i];
       final FileMapData expectedData = expected[i];
       Assert.assertEquals(data.toString(), expectedData.toString(), data.toString());
     }

--- a/util/src/com/intellij/rt/coverage/instrumentation/JSR45Util.java
+++ b/util/src/com/intellij/rt/coverage/instrumentation/JSR45Util.java
@@ -23,10 +23,7 @@ import org.jetbrains.coverage.gnu.trove.THashSet;
 import org.jetbrains.coverage.gnu.trove.TIntObjectHashMap;
 import org.jetbrains.coverage.gnu.trove.TObjectFunction;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
  * @author anna
@@ -36,6 +33,8 @@ public class JSR45Util {
   private static final String FILE_SECTION = "*F\n";
   private static final String LINE_SECTION = "*L\n";
   private static final String END_SECTION = "*E";
+
+  private static final LineMapData[] EMPTY_LINE_MAP = new LineMapData[0];
 
   private static String checkSMAP(String debug) {
     return debug.startsWith("SMAP") ? debug.substring(4) : null;
@@ -187,20 +186,20 @@ public class JSR45Util {
   }
 
   private static LineMapData[] getLinesMapping(THashSet<LineMapData> linesMap) {
-
-    int max = 0;
-    for (Object aLinesMap1 : linesMap) {
-      LineMapData lmd = (LineMapData) aLinesMap1;
-      if (max < lmd.getSourceLineNumber()) {
-        max = lmd.getSourceLineNumber();
+    final LineMapData[] result = linesMap.toArray(EMPTY_LINE_MAP);
+    Arrays.sort(result, new Comparator<LineMapData>() {
+      public int compare(LineMapData o1, LineMapData o2) {
+        int compareSource = o1.getSourceLineNumber() - o2.getSourceLineNumber();
+        if (compareSource == 0) {
+          int compareMin = o1.getTargetMinLine() - o2.getTargetMinLine();
+          if (compareMin == 0) {
+            return o1.getTargetMaxLine() - o2.getTargetMaxLine();
+          }
+          return compareMin;
+        }
+        return compareSource;
       }
-    }
-
-    final LineMapData[] result = new LineMapData[max + 1];
-    for (Object aLinesMap : linesMap) {
-      LineMapData lmd = (LineMapData) aLinesMap;
-      result[lmd.getSourceLineNumber()] = lmd;
-    }
+    });
     return result;
   }
 


### PR DESCRIPTION
1) Fixed SMAP data usage, now all the lines mapped to a single Kotlin line are taken into account.
2) Kotlin synthetic access methods are ignored 