### PR TITLE
Add kotlin disable system property

### DIFF
--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/Instrumenter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/Instrumenter.java
@@ -19,11 +19,9 @@ package com.intellij.rt.coverage.instrumentation;
 import com.intellij.rt.coverage.data.ClassData;
 import com.intellij.rt.coverage.data.LineData;
 import com.intellij.rt.coverage.data.ProjectData;
-import com.intellij.rt.coverage.instrumentation.filters.signature.KotlinSyntheticAccessMethodFilter;
-import com.intellij.rt.coverage.instrumentation.filters.signature.KotlinSyntheticConstructorOfSealedClassFilter;
 import com.intellij.rt.coverage.instrumentation.filters.signature.MethodSignatureFilter;
-import com.intellij.rt.coverage.instrumentation.filters.visiting.KotlinImplementerDefaultInterfaceMemberFilter;
 import com.intellij.rt.coverage.instrumentation.filters.visiting.MethodVisitingFilter;
+import com.intellij.rt.coverage.instrumentation.kotlin.KotlinUtils;
 import com.intellij.rt.coverage.util.StringsPool;
 import org.jetbrains.coverage.gnu.trove.TIntObjectHashMap;
 import org.jetbrains.coverage.org.objectweb.asm.AnnotationVisitor;
@@ -188,15 +186,10 @@ public abstract class Instrumenter extends ClassVisitor {
   }
 
   private static List<MethodVisitingFilter> createVisitingFilters() {
-    List<MethodVisitingFilter> result = new ArrayList<MethodVisitingFilter>();
-    result.add(new KotlinImplementerDefaultInterfaceMemberFilter());
-    return result;
+    return KotlinUtils.createVisitingFilters();
   }
 
   private static List<MethodSignatureFilter> getMethodSignatureFilters() {
-    List<MethodSignatureFilter> result = new ArrayList<MethodSignatureFilter>();
-    result.add(new KotlinSyntheticConstructorOfSealedClassFilter());
-    result.add(new KotlinSyntheticAccessMethodFilter());
-    return result;
+    return KotlinUtils.createSignatureFilters();
   }
 }

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/LineEnumerator.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/LineEnumerator.java
@@ -18,9 +18,8 @@ package com.intellij.rt.coverage.instrumentation;
 
 import com.intellij.rt.coverage.data.LineData;
 import com.intellij.rt.coverage.data.SwitchData;
-import com.intellij.rt.coverage.instrumentation.filters.enumerating.KotlinDefaultArgsBranchFilter;
-import com.intellij.rt.coverage.instrumentation.filters.enumerating.KotlinWhenMappingExceptionFilter;
 import com.intellij.rt.coverage.instrumentation.filters.enumerating.LineEnumeratorFilter;
+import com.intellij.rt.coverage.instrumentation.kotlin.KotlinUtils;
 import com.intellij.rt.coverage.util.ClassNameUtil;
 import org.jetbrains.coverage.org.objectweb.asm.Label;
 import org.jetbrains.coverage.org.objectweb.asm.MethodVisitor;
@@ -312,9 +311,6 @@ public class LineEnumerator extends MethodVisitor implements Opcodes {
   }
 
   private static List<LineEnumeratorFilter> createLineEnumeratorFilters() {
-    List<LineEnumeratorFilter> result = new ArrayList<LineEnumeratorFilter>();
-    result.add(new KotlinWhenMappingExceptionFilter());
-    result.add(new KotlinDefaultArgsBranchFilter());
-    return result;
+    return KotlinUtils.createLineEnumeratorFilters();
   }
 }

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/kotlin/KotlinUtils.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/kotlin/KotlinUtils.java
@@ -17,6 +17,18 @@
 package com.intellij.rt.coverage.instrumentation.kotlin;
 
 import com.intellij.rt.coverage.instrumentation.Instrumenter;
+import com.intellij.rt.coverage.instrumentation.filters.enumerating.KotlinDefaultArgsBranchFilter;
+import com.intellij.rt.coverage.instrumentation.filters.enumerating.KotlinWhenMappingExceptionFilter;
+import com.intellij.rt.coverage.instrumentation.filters.enumerating.LineEnumeratorFilter;
+import com.intellij.rt.coverage.instrumentation.filters.signature.KotlinSyntheticAccessMethodFilter;
+import com.intellij.rt.coverage.instrumentation.filters.signature.KotlinSyntheticConstructorOfSealedClassFilter;
+import com.intellij.rt.coverage.instrumentation.filters.signature.MethodSignatureFilter;
+import com.intellij.rt.coverage.instrumentation.filters.visiting.KotlinImplementerDefaultInterfaceMemberFilter;
+import com.intellij.rt.coverage.instrumentation.filters.visiting.MethodVisitingFilter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class KotlinUtils {
   private static final String KOTLIN_CLASS_LABEL = "IS_KOTLIN";
@@ -27,5 +39,30 @@ public class KotlinUtils {
     boolean isKotlin = context.getAnnotations().contains("Lkotlin/Metadata;");
     context.addProperty(KOTLIN_CLASS_LABEL, isKotlin);
     return isKotlin;
+  }
+
+  private static final boolean ourKotlinEnabled = !"false".equals(System.getProperty("coverage.kotlin.enable", "true"));
+
+  public static List<MethodSignatureFilter> createSignatureFilters() {
+    if (!ourKotlinEnabled) return Collections.emptyList();
+    List<MethodSignatureFilter> result = new ArrayList<MethodSignatureFilter>();
+    result.add(new KotlinSyntheticConstructorOfSealedClassFilter());
+    result.add(new KotlinSyntheticAccessMethodFilter());
+    return result;
+  }
+
+  public static List<MethodVisitingFilter> createVisitingFilters() {
+    if (!ourKotlinEnabled) return Collections.emptyList();
+    List<MethodVisitingFilter> result = new ArrayList<MethodVisitingFilter>();
+    result.add(new KotlinImplementerDefaultInterfaceMemberFilter());
+    return result;
+  }
+
+  public static List<LineEnumeratorFilter> createLineEnumeratorFilters() {
+    if (!ourKotlinEnabled) return Collections.emptyList();
+    List<LineEnumeratorFilter> result = new ArrayList<LineEnumeratorFilter>();
+    result.add(new KotlinWhenMappingExceptionFilter());
+    result.add(new KotlinDefaultArgsBranchFilter());
+    return result;
   }
 }


### PR DESCRIPTION
Now Kotlin filters can be disabled with running agent with `-Dcoverage.kotlin.disable=true` option.