### PR TITLE
Fix IDEA-57695

### DIFF
--- a/src/com/intellij/rt/coverage/data/JumpsAndSwitches.java
+++ b/src/com/intellij/rt/coverage/data/JumpsAndSwitches.java
@@ -89,8 +89,8 @@ public class JumpsAndSwitches implements CoverageData {
   }
 
   public void removeJump(final int jump) {
-    if (jump > 0 && jump <= myJumps.size()) {
-      myJumps.remove(jump - 1);
+    if (0 <= jump && jump < myJumps.size()) {
+      myJumps.remove(jump);
     }
   }
 
@@ -163,5 +163,11 @@ public class JumpsAndSwitches implements CoverageData {
       }
       switchData.merge(array[i]);
     }
+  }
+
+  public int jumpsCount() {
+    if (myJumps != null) return myJumps.size();
+    if (myJumpsArray != null) return myJumpsArray.length;
+    return 0;
   }
 }

--- a/src/com/intellij/rt/coverage/data/LineData.java
+++ b/src/com/intellij/rt/coverage/data/LineData.java
@@ -124,6 +124,11 @@ public class LineData implements CoverageData {
     }
   }
 
+  public int jumpsCount() {
+    if (myJumpsAndSwitches == null) return 0;
+    return myJumpsAndSwitches.jumpsCount();
+  }
+
   public JumpData addJump(final int jump) {
     return getOrCreateJumpsAndSwitches().addJump(jump);
   }

--- a/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
@@ -42,6 +42,9 @@ class KotlinCoverageStatusTest {
     }
 
     @Test
+    fun testSimpleIfElse() = test("simple.ifelse", sampling = false)
+
+    @Test
     fun testDefaultArgsCovered() = test("defaultArgs.covered")
 
     @Test
@@ -133,6 +136,12 @@ class KotlinCoverageStatusTest {
 
     @Test
     fun testFunInterface() = test("funInterface", "TestKt", "TestKt\$test\$1")
+
+    @Test
+    fun test_IDEA_57695() {
+        val project = runWithCoverage(myDataFile, "fixes.IDEA_57695", false)
+        assertEqualsLines(project, hashMapOf(1 to "PARTIAL", 2 to "FULL"), listOf("kotlinTestData.fixes.IDEA_57695.TestClass"))
+    }
 
     @Test
     fun test_IDEA_250825() = test("fixes.IDEA_250825", "JavaTest", fileName = "JavaTest.java", sampling = false)

--- a/test-kotlin/src/com/intellij/rt/coverage/runner.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/runner.kt
@@ -24,7 +24,7 @@ import java.io.File
 import java.nio.file.Paths
 
 
-fun runWithCoverage(coverageDataFile: File, testName: String, sampling: Boolean, calcUnloaded: Boolean): ProjectData {
+fun runWithCoverage(coverageDataFile: File, testName: String, sampling: Boolean, calcUnloaded: Boolean = false): ProjectData {
     val classPath = System.getProperty("java.class.path")
     return CoverageStatusTest.runCoverage(classPath, coverageDataFile, "kotlinTestData.*", "kotlinTestData.$testName.Test", sampling, calcUnloaded)
 }

--- a/test-kotlin/src/kotlinTestData/fixes/IDEA_57695/test.kt
+++ b/test-kotlin/src/kotlinTestData/fixes/IDEA_57695/test.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.fixes.IDEA_57695
+
+import kotlinTestData.fixes.IDEA_57695.GeneratorClassLoader.foo
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.coverage.org.objectweb.asm.ClassWriter
+import org.jetbrains.coverage.org.objectweb.asm.Label
+import org.jetbrains.coverage.org.objectweb.asm.Opcodes
+
+/**
+ * This loader generates bytecode equivalent to [foo].
+ */
+private object GeneratorClassLoader : ClassLoader() {
+    const val BASE_NAME = "kotlinTestData.fixes.IDEA_57695"
+    const val METHOD_NAME = "foo"
+    private const val REPORT_NULL_NAME = "\$\$\$reportNull\$\$\$"
+    private const val REPORT_NULL_SIGNATURE = "(I)V"
+    private const val OBJECT = "java/lang/Object"
+
+    @NotNull
+    fun foo(x: Any?): Any? {
+        return if (x == null)
+            null else x
+    }
+
+    override fun loadClass(name: String?): Class<*>? = if (name != null && name.startsWith(BASE_NAME)) {
+        val generated = generate(name.replace('.', '/'))
+        defineClass(name, generated, 0, generated.size)
+    } else {
+        super.loadClass(name)
+    }
+
+    private fun generate(name: String): ByteArray {
+        val cw = ClassWriter(0)
+        cw.visit(49, Opcodes.ACC_PUBLIC, name, null, OBJECT, null)
+
+        val mv1 = cw.visitMethod(Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, REPORT_NULL_NAME, REPORT_NULL_SIGNATURE, null, null)
+        mv1.visitInsn(Opcodes.RETURN)
+        mv1.visitMaxs(1, 1)
+        mv1.visitEnd()
+
+        val mv2 = cw.visitMethod(Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, METHOD_NAME, "(L$OBJECT;)L$OBJECT;", null, null)
+        val line1 = Label()
+        mv2.visitLabel(line1)
+        mv2.visitLineNumber(1, line1)
+
+        mv2.visitVarInsn(Opcodes.ALOAD, 0)
+        val ifLabel = Label()
+        val returnOnLine1 = Label()
+        mv2.visitJumpInsn(Opcodes.IFNULL, ifLabel)
+
+        val line2 = Label()
+        mv2.visitLabel(line2)
+        mv2.visitLineNumber(2, line2)
+
+        mv2.visitVarInsn(Opcodes.ALOAD, 0)
+        mv2.visitJumpInsn(Opcodes.GOTO, returnOnLine1)
+
+        mv2.visitLabel(ifLabel)
+        mv2.visitInsn(Opcodes.ACONST_NULL)
+
+        mv2.visitLabel(returnOnLine1)
+        mv2.visitLineNumber(1, returnOnLine1)
+
+        mv2.visitInsn(Opcodes.DUP)
+        val returnLabel = Label()
+        mv2.visitJumpInsn(Opcodes.IFNONNULL, returnLabel)
+        mv2.visitInsn(Opcodes.ICONST_0)
+        mv2.visitMethodInsn(Opcodes.INVOKESTATIC, name, REPORT_NULL_NAME, REPORT_NULL_SIGNATURE, false)
+
+        mv2.visitLabel(returnLabel)
+        mv2.visitInsn(Opcodes.ARETURN)
+        mv2.visitMaxs(2, 1)
+        mv2.visitEnd()
+
+        cw.visitEnd()
+        return cw.toByteArray()
+    }
+}
+
+fun test() {
+    val clazz = GeneratorClassLoader.loadClass("${GeneratorClassLoader.BASE_NAME}.TestClass")!!
+    clazz.getMethod(GeneratorClassLoader.METHOD_NAME, Any::class.java).invoke(null, Any())
+}
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        test()
+    }
+}

--- a/test-kotlin/src/kotlinTestData/simple/ifelse/test.kt
+++ b/test-kotlin/src/kotlinTestData/simple/ifelse/test.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.simple.ifelse
+
+fun test(x: Boolean, y: Boolean, z: Boolean) {
+    if (x) {                  // coverage: PARTIAL
+        println("X is true")  // coverage: FULL
+    } else {
+        println("X is false") // coverage: NONE
+    }                         // coverage: FULL
+    if (y) {                  // coverage: PARTIAL
+        println("Y is true")  // coverage: NONE
+    }
+    if (z) {                  // coverage: PARTIAL
+        println("Y is true")  // coverage: FULL
+        return
+    }
+}
+
+fun test2(x: Boolean, y: Boolean) {
+    if (x) {                  // coverage: FULL
+        println("X is true")  // coverage: FULL
+    } else {
+        println("X is false") // coverage: FULL
+    }                         // coverage: FULL
+    if (y) {                  // coverage: PARTIAL
+        println("Y is true")  // coverage: FULL
+    }
+}
+
+
+fun test3(b: Boolean) {
+    if (!b) {            // coverage: PARTIAL
+        while (b) {      // coverage: PARTIAL
+            println("")  // coverage: NONE
+        }
+    }
+}
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        test(x = true, y = false, z = true)
+        test2(x = true, y = true)
+        test2(x = false, y = true)
+        test3(false)
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-57695

If a LINENUMBER instruction for the same line appeared twice, jump counter in `LineEnumerator` had reset to zero. Then `removeLastJump` operation caused other jump removal.

Now labels are used instead of counters for jumps identification.