### PR TITLE
Test IDEA_250825

### DIFF
--- a/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
@@ -134,6 +134,9 @@ class KotlinCoverageStatusTest {
     @Test
     fun testFunInterface() = test("funInterface", "TestKt", "TestKt\$test\$1")
 
+    @Test
+    fun test_IDEA_250825() = test("fixes.IDEA_250825", "JavaTest", fileName = "JavaTest.java", sampling = false)
+
     private fun test(testName: String, vararg classes: String = arrayOf("TestKt"),
                      sampling: Boolean = true, fileName: String = "test.kt",
                      calcUnloaded: Boolean = false) {

--- a/test-kotlin/src/kotlinTestData/fixes/IDEA_250825/JavaTest.java
+++ b/test-kotlin/src/kotlinTestData/fixes/IDEA_250825/JavaTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.fixes.IDEA_250825;
+
+public class JavaTest {                      // coverage: FULL
+  void doTest(int a, int b, int c) {
+    if (a < b) {                             // coverage: FULL
+      System.out.println("a < b");           // coverage: FULL
+    }
+    else if (b < c) {                        // coverage: FULL
+      System.out.println("a >= b && b < c"); // coverage: FULL
+    }
+  }
+}

--- a/test-kotlin/src/kotlinTestData/fixes/IDEA_250825/test.kt
+++ b/test-kotlin/src/kotlinTestData/fixes/IDEA_250825/test.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.fixes.IDEA_250825
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val test = JavaTest()
+        test.doTest(1, 2, 2)
+        test.doTest(2, 2, 3)
+        test.doTest(2, 2, 1)
+    }
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-250825 was fixed in #14 by using `SaveLabelsMethodNode`.
Namely, there was the case when a label has been seen before `visitJumpInstrunction` and appropriate LabelNode has been already created but has not had label set.