### PR TITLE
Fix IDEA-224511: (NPE) add null check for classData object

### DIFF
--- a/src/com/intellij/rt/coverage/data/ProjectData.java
+++ b/src/com/intellij/rt/coverage/data/ProjectData.java
@@ -235,7 +235,7 @@ public class ProjectData implements CoverageData, Serializable {
   // -------------------------------------------------------------------------------------------------- //
 
   public static void touchLine(Object classData, int line) {
-    if (ourProjectData != null) {
+    if (ourProjectData != null && classData != null) {
       ((ClassData) classData).touchLine(line);
       return;
     }
@@ -245,7 +245,7 @@ public class ProjectData implements CoverageData, Serializable {
   }
 
   public static void touchSwitch(Object classData, int line, int switchNumber, int key) {
-    if (ourProjectData != null) {
+    if (ourProjectData != null && classData != null) {
       ((ClassData) classData).touch(line, switchNumber, key);
       return;
     }
@@ -255,7 +255,7 @@ public class ProjectData implements CoverageData, Serializable {
   }
 
   public static void touchJump(Object classData, int line, int jump, boolean hit) {
-    if (ourProjectData != null) {
+    if (ourProjectData != null && classData != null) {
       ((ClassData) classData).touch(line, jump, hit);
       return;
     }
@@ -265,7 +265,7 @@ public class ProjectData implements CoverageData, Serializable {
   }
 
   public static void trace(Object classData, int line) {
-    if (ourProjectData != null) {
+    if (ourProjectData != null && classData != null) {
       ((ClassData) classData).touch(line);
       ourProjectData.traceLine((ClassData) classData, line);
       return;


### PR DESCRIPTION
When running unit tests with coverage, sometimes the method
ProjectData.touchLine() method is called with a null object.

When looking at the NPE stacktrace, it always is associated
with a class from the a maven sources jar (*-sources.jar).

To reproduce: add all the *-sources.jar and *-sources.jar.sha1
for all external maven dependencies to your maven repository
and run a test-with-coverage.

- Add a null check for classData object inside touchLine()