### PR TITLE
Fix: recover API compatibility

### DIFF
--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/SaveHook.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/SaveHook.java
@@ -47,6 +47,10 @@ public class SaveHook implements Runnable {
     private final ClassFinder myClassFinder;
     private final ReportFormat myFormat;
 
+    public SaveHook(File dataFile, boolean appendUnloaded, ClassFinder classFinder) {
+        this(dataFile, appendUnloaded, classFinder, ReportFormat.BINARY);
+    }
+
     public SaveHook(File dataFile, boolean appendUnloaded, ClassFinder classFinder, ReportFormat format) {
         myDataFile = dataFile;
         myAppendUnloaded = appendUnloaded;


### PR DESCRIPTION
`SaveHook` constructor changed after adding XML option. 