### PR TITLE
Implement private constructor of util class filter

### DIFF
--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/CoverageClassfileTransformer.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/CoverageClassfileTransformer.java
@@ -17,6 +17,8 @@
 package com.intellij.rt.coverage.instrumentation;
 
 import com.intellij.rt.coverage.data.ProjectData;
+import com.intellij.rt.coverage.instrumentation.filters.FilterUtils;
+import com.intellij.rt.coverage.instrumentation.filters.classFilter.PrivateConstructorOfUtilClassFilter;
 import com.intellij.rt.coverage.util.ClassNameUtil;
 import com.intellij.rt.coverage.util.classFinder.ClassFinder;
 import org.jetbrains.coverage.org.objectweb.asm.ClassReader;
@@ -43,16 +45,22 @@ public class CoverageClassfileTransformer extends AbstractIntellijClassfileTrans
 
   @Override
   protected ClassVisitor createClassVisitor(String className, ClassLoader loader, ClassReader cr, ClassWriter cw) {
+    final Instrumenter instrumenter;
     if (data.isSampling()) {
       if (System.getProperty("idea.new.sampling.coverage") != null) {
         //wrap cw with new TraceClassVisitor(cw, new PrintWriter(new StringWriter())) to get readable bytecode
-        return new NewSamplingInstrumenter(data, cw, cr, className, shouldCalculateSource);
+        instrumenter = new NewSamplingInstrumenter(data, cw, cr, className, shouldCalculateSource);
       } else {
-        return new SamplingInstrumenter(data, cw, className, shouldCalculateSource);
+        instrumenter = new SamplingInstrumenter(data, cw, className, shouldCalculateSource);
       }
     } else {
-      return new ClassInstrumenter(data, cw, className, shouldCalculateSource);
+      instrumenter = new ClassInstrumenter(data, cw, className, shouldCalculateSource);
     }
+    ClassVisitor result = instrumenter;
+    if (FilterUtils.ignorePrivateConstructorOfUtilClassEnabled()) {
+      result = PrivateConstructorOfUtilClassFilter.createWithContext(result, instrumenter);
+    }
+    return result;
   }
 
   @Override

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/FilterUtils.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/FilterUtils.java
@@ -27,6 +27,13 @@ import com.intellij.rt.coverage.instrumentation.kotlin.KotlinUtils;
 import java.util.List;
 
 public class FilterUtils {
+  private static final boolean ourIgnorePrivateConstructorOfUtilClass =
+      "true".equals(System.getProperty("coverage.ignore.private.constructor.util.class", "false"));
+
+  public static boolean ignorePrivateConstructorOfUtilClassEnabled() {
+    return ourIgnorePrivateConstructorOfUtilClass;
+  }
+
   public static List<MethodSignatureFilter> createSignatureFilters() {
     List<MethodSignatureFilter> result = KotlinUtils.createSignatureFilters();
     result.add(new EnumMethodsFilter());

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/classFilter/PrivateConstructorOfUtilClassFilter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/filters/classFilter/PrivateConstructorOfUtilClassFilter.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2000-2021 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.instrumentation.filters.classFilter;
+
+import com.intellij.rt.coverage.instrumentation.Instrumenter;
+import com.intellij.rt.coverage.instrumentation.kotlin.KotlinUtils;
+import org.jetbrains.coverage.org.objectweb.asm.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class PrivateConstructorOfUtilClassFilter extends ClassVisitor {
+  private static final String CONSTRUCTOR = "<init>";
+  private static final String CONSTRUCTOR_DESCRIPTOR = "()V";
+
+  private boolean myAllMethodsStatic = true;
+  private boolean myIsKotlinObject = false;
+  private boolean myIsKotlinClass = false;
+  private boolean myConstructorIsEmpty = true;
+  private List<Integer> myConstructorLines;
+  private String myName;
+  private String mySuperName;
+
+  public PrivateConstructorOfUtilClassFilter(ClassVisitor classVisitor) {
+    super(Opcodes.API_VERSION, classVisitor);
+  }
+
+  protected abstract void removeLine(int line);
+
+  @Override
+  public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+    super.visit(version, access, name, signature, superName, interfaces);
+    myName = name;
+    mySuperName = superName;
+  }
+
+  @Override
+  public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+    myIsKotlinObject |= (access & (Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL)) != 0
+        && "INSTANCE".equals(name)
+        && myName.equals(Type.getType(descriptor).getInternalName());
+    return super.visitField(access, name, descriptor, signature, value);
+  }
+
+  @Override
+  public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+    MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+    if (isPrivateDefaultConstructor(access, name, descriptor)) {
+      return new EmptyConstructorVisitor(mv);
+    }
+    myAllMethodsStatic &= (access & Opcodes.ACC_STATIC) != 0;
+    return mv;
+  }
+
+  @Override
+  public void visitEnd() {
+    if ((myAllMethodsStatic || myIsKotlinObject && myIsKotlinClass)
+        && myConstructorIsEmpty
+        && myConstructorLines != null) {
+      for (int line : myConstructorLines) {
+        removeLine(line);
+      }
+    }
+    super.visitEnd();
+  }
+
+  @Override
+  public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+    myIsKotlinClass |= KotlinUtils.KOTLIN_METADATA.equals(descriptor);
+    return super.visitAnnotation(descriptor, visible);
+  }
+
+  private class EmptyConstructorVisitor extends MethodVisitor {
+    private boolean myALoadVisited = false;
+    private boolean myInvokeSpecialVisited = false;
+
+    public EmptyConstructorVisitor(MethodVisitor methodVisitor) {
+      super(Opcodes.API_VERSION, methodVisitor);
+    }
+
+    @Override
+    public void visitLineNumber(int line, Label start) {
+      super.visitLineNumber(line, start);
+      addLine(line);
+    }
+
+    @Override
+    public void visitVarInsn(int opcode, int var) {
+      super.visitVarInsn(opcode, var);
+      if (opcode == Opcodes.ALOAD && var == 0) {
+        myALoadVisited = true;
+        return;
+      }
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+      super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+      if (myALoadVisited
+          && opcode == Opcodes.INVOKESPECIAL
+          && owner != null && owner.equals(mySuperName)
+          && CONSTRUCTOR.equals(name)
+          && CONSTRUCTOR_DESCRIPTOR.equals(descriptor)) {
+        myInvokeSpecialVisited = true;
+        return;
+      }
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitInsn(int opcode) {
+      super.visitInsn(opcode);
+      if (myInvokeSpecialVisited && opcode == Opcodes.RETURN) {
+        return;
+      }
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
+      super.visitInvokeDynamicInsn(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
+      super.visitFieldInsn(opcode, owner, name, descriptor);
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitMultiANewArrayInsn(String descriptor, int numDimensions) {
+      super.visitMultiANewArrayInsn(descriptor, numDimensions);
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitTypeInsn(int opcode, String type) {
+      super.visitTypeInsn(opcode, type);
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitIntInsn(int opcode, int operand) {
+      super.visitIntInsn(opcode, operand);
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitLdcInsn(Object value) {
+      super.visitLdcInsn(value);
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitJumpInsn(int opcode, Label label) {
+      super.visitJumpInsn(opcode, label);
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitIincInsn(int var, int increment) {
+      super.visitIincInsn(var, increment);
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
+      super.visitLookupSwitchInsn(dflt, keys, labels);
+      myConstructorIsEmpty = false;
+    }
+
+    @Override
+    public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels) {
+      super.visitTableSwitchInsn(min, max, dflt, labels);
+      myConstructorIsEmpty = false;
+    }
+  }
+
+  private static boolean isPrivateDefaultConstructor(int access, String name, String descriptor) {
+    return (access & Opcodes.ACC_PRIVATE) != 0 && CONSTRUCTOR.equals(name) && CONSTRUCTOR_DESCRIPTOR.equals(descriptor);
+  }
+
+  private void addLine(int line) {
+    if (myConstructorLines == null) {
+      myConstructorLines = new ArrayList<Integer>();
+    }
+    myConstructorLines.add(line);
+  }
+
+
+  public static PrivateConstructorOfUtilClassFilter createWithContext(ClassVisitor cv, final Instrumenter context) {
+    return new PrivateConstructorOfUtilClassFilter(cv) {
+      @Override
+      protected void removeLine(int line) {
+        context.removeLine(line);
+      }
+    };
+  }
+}

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/kotlin/KotlinUtils.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/kotlin/KotlinUtils.java
@@ -34,11 +34,12 @@ import java.util.List;
 
 public class KotlinUtils {
   private static final String KOTLIN_CLASS_LABEL = "IS_KOTLIN";
+  public static final String KOTLIN_METADATA = "Lkotlin/Metadata;";
 
   public static boolean isKotlinClass(MethodFilteringVisitor context) {
     Object currentProperty = context.getProperty(KOTLIN_CLASS_LABEL);
     if (currentProperty instanceof Boolean) return (Boolean) currentProperty;
-    boolean isKotlin = context.getAnnotations().contains("Lkotlin/Metadata;");
+    boolean isKotlin = context.getAnnotations().contains(KOTLIN_METADATA);
     context.addProperty(KOTLIN_CLASS_LABEL, isKotlin);
     return isKotlin;
   }

--- a/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusSamplingTest.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusSamplingTest.kt
@@ -149,7 +149,7 @@ abstract class KotlinCoverageStatusAbstractSamplingTest : KotlinCoverageStatusTe
             fileName = "JavaTest.java", extraArgs = mutableListOf(IGNORE_UTIL_PRIVATE_CONSTRUCTOR_OPTION), calcUnloaded = true)
 
     @Test
-    fun testKotlinObject() = test("utilClass.kotlin", "Util", "UnusedObject",
+    fun testKotlinObject() = test("utilClass.kotlin", "Util", "UnusedObject", "SimpleClassWithDefaultConstructor\$Companion",
             extraArgs = mutableListOf(IGNORE_UTIL_PRIVATE_CONSTRUCTOR_OPTION), calcUnloaded = true)
 }
 

--- a/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusSamplingTest.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusSamplingTest.kt
@@ -143,6 +143,14 @@ abstract class KotlinCoverageStatusAbstractSamplingTest : KotlinCoverageStatusTe
 
     @Test
     fun test_KT_39038() = test("fixes.KT_39038")
+
+    @Test
+    fun testUtilJavaClass() = test("utilClass.java", "JavaTest", "JavaTest\$UnusedJavaTest",
+            fileName = "JavaTest.java", extraArgs = mutableListOf(IGNORE_UTIL_PRIVATE_CONSTRUCTOR_OPTION), calcUnloaded = true)
+
+    @Test
+    fun testKotlinObject() = test("utilClass.kotlin", "Util", "UnusedObject",
+            extraArgs = mutableListOf(IGNORE_UTIL_PRIVATE_CONSTRUCTOR_OPTION), calcUnloaded = true)
 }
 
 class KotlinCoverageStatusSamplingTest : KotlinCoverageStatusAbstractSamplingTest() {

--- a/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/kotlin/KotlinCoverageStatusTest.kt
@@ -39,10 +39,11 @@ abstract class KotlinCoverageStatusTest {
     abstract val coverage: Coverage
 
     protected fun test(testName: String, vararg classes: String = arrayOf("TestKt"),
-                       fileName: String = "test.kt", calcUnloaded: Boolean = false) {
+                       fileName: String = "test.kt", calcUnloaded: Boolean = false,
+                       extraArgs: MutableList<String> = mutableListOf()) {
         val testFile = pathToFile("src", "kotlinTestData", *testName.split('.').toTypedArray(), fileName)
         val expected = extractCoverageDataFromFile(testFile)
-        val project = runWithCoverage(myDataFile, testName, coverage, calcUnloaded)
+        val project = runWithCoverage(myDataFile, testName, coverage, calcUnloaded, extraArgs = extraArgs)
         val fullClassNames = classes.map { "kotlinTestData.$testName.$it" }
         assertEqualsLines(project, expected, if (classes.contains(all)) listOf(all) else fullClassNames)
     }

--- a/test-kotlin/src/com/intellij/rt/coverage/runner.kt
+++ b/test-kotlin/src/com/intellij/rt/coverage/runner.kt
@@ -28,13 +28,15 @@ enum class Coverage {
 }
 
 private const val TEST_PACKAGE = "kotlinTestData"
+internal const val IGNORE_UTIL_PRIVATE_CONSTRUCTOR_OPTION = "-Dcoverage.ignore.private.constructor.util.class=true"
 
 fun runWithCoverage(coverageDataFile: File, testName: String, coverage: Coverage, calcUnloaded: Boolean = false,
-                    patterns: String = "$TEST_PACKAGE.*"): ProjectData {
+                    patterns: String = "$TEST_PACKAGE.*", extraArgs: MutableList<String> = mutableListOf()): ProjectData {
     val classPath = System.getProperty("java.class.path")
-    val extraArgs = if (coverage == Coverage.NEW_SAMPLING) arrayOf("-Didea.new.sampling.coverage=true") else emptyArray()
+    if (coverage == Coverage.NEW_SAMPLING) extraArgs.add("-Didea.new.sampling.coverage=true")
     val sampling = coverage != Coverage.TRACING
-    return CoverageStatusTest.runCoverage(classPath, coverageDataFile, patterns, "kotlinTestData.$testName.Test", sampling, extraArgs, calcUnloaded)
+    return CoverageStatusTest.runCoverage(classPath, coverageDataFile, patterns, "kotlinTestData.$testName.Test",
+            sampling, extraArgs.toTypedArray(), calcUnloaded)
 }
 
 internal fun assertEqualsLines(project: ProjectData, expectedLines: Map<Int, String>, classNames: List<String>) {

--- a/test-kotlin/src/kotlinTestData/utilClass/java/JavaTest.java
+++ b/test-kotlin/src/kotlinTestData/utilClass/java/JavaTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2021 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.utilClass.java;
+
+public class JavaTest {
+  private JavaTest() {                // should be ignored
+  }
+
+  public static void help1() {
+    System.out.println("I'm help 1"); // coverage: FULL
+  }
+
+  private static void help2() {
+    System.out.println("I'm help 2"); // coverage: NONE
+  }
+
+  public static class UnusedJavaTest {
+    private UnusedJavaTest() {    // should be ignored
+    }
+
+    public static void help() {
+    }                             // coverage: NONE
+  }
+}

--- a/test-kotlin/src/kotlinTestData/utilClass/java/test.kt
+++ b/test-kotlin/src/kotlinTestData/utilClass/java/test.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2000-2021 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.utilClass.java
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        JavaTest.help1()
+    }
+}

--- a/test-kotlin/src/kotlinTestData/utilClass/kotlin/test.kt
+++ b/test-kotlin/src/kotlinTestData/utilClass/kotlin/test.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2021 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinTestData.utilClass.kotlin
+
+object Util {        // should be ignored
+    val x = foo2()   // coverage: FULL
+    var y = 4        // coverage: FULL
+    fun foo1() {
+        print(x)     // coverage: FULL
+    }
+
+    private fun foo2(): Int {
+        y = 3        // coverage: FULL
+        return 42    // coverage: FULL
+    }
+}
+
+
+object UnusedObject { // should be ignored
+    fun boo() {
+    }                 // coverage: NONE
+}
+
+object Test {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        Util.foo1()
+    }
+}

--- a/test-kotlin/src/kotlinTestData/utilClass/kotlin/test.kt
+++ b/test-kotlin/src/kotlinTestData/utilClass/kotlin/test.kt
@@ -35,9 +35,18 @@ object UnusedObject { // should be ignored
     }                 // coverage: NONE
 }
 
+class SimpleClassWithDefaultConstructor {
+    companion object {
+        fun staticFoo() {
+            println()   // coverage: FULL
+        }
+    }
+}
+
 object Test {
     @JvmStatic
     fun main(args: Array<String>) {
         Util.foo1()
+        SimpleClassWithDefaultConstructor.staticFoo()
     }
 }


### PR DESCRIPTION
Ignore private constructor for util classes(all static methods) and kotlin objects.
Filtering is enabled by option `-Dcoverage.ignore.private.constructor.util.class=true` or with a flag for unloaded classes(SourceLineCounter).