### PR TITLE
Consider if as 2 branches, fix uncovered classes branch count

### DIFF
--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/SourceLineCounter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/SourceLineCounter.java
@@ -190,14 +190,14 @@ public class SourceLineCounter extends ClassVisitor {
       public void visitTableSwitchInsn(final int min, final int max, final Label dflt, final Label[] labels) {
         super.visitTableSwitchInsn(min, max, dflt, labels);
         myHasInstructions = true;
-        myTotalBranches += labels.length + 1;
+        myTotalBranches += labels.length;
       }
 
 
       public void visitLookupSwitchInsn(final Label dflt, final int[] keys, final Label[] labels) {
         super.visitLookupSwitchInsn(dflt, keys, labels);
         myHasInstructions = true;
-        myTotalBranches += labels.length + 1;
+        myTotalBranches += labels.length;
       }
 
 

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/SourceLineCounter.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/SourceLineCounter.java
@@ -171,7 +171,7 @@ public class SourceLineCounter extends ClassVisitor {
         super.visitJumpInsn(opcode, label);
         myHasInstructions = true;
         if (opcode != Opcodes.GOTO && opcode != Opcodes.JSR) {
-          myTotalBranches++;
+          myTotalBranches += 2;
         }
       }
 
@@ -190,14 +190,14 @@ public class SourceLineCounter extends ClassVisitor {
       public void visitTableSwitchInsn(final int min, final int max, final Label dflt, final Label[] labels) {
         super.visitTableSwitchInsn(min, max, dflt, labels);
         myHasInstructions = true;
-        myTotalBranches++;
+        myTotalBranches += labels.length + 1;
       }
 
 
       public void visitLookupSwitchInsn(final Label dflt, final int[] keys, final Label[] labels) {
         super.visitLookupSwitchInsn(dflt, keys, labels);
         myHasInstructions = true;
-        myTotalBranches++;
+        myTotalBranches += labels.length + 1;
       }
 
 

--- a/reporter/resources/xmlIntegrationTest.xml
+++ b/reporter/resources/xmlIntegrationTest.xml
@@ -3,36 +3,39 @@
 <package name="testData/simple">
 <class name="testData/simple/Main" sourcefilename="Main.java">
 <method name="main" desc="([Ljava/lang/String;)V">
-<counter type="INSTRUCTION" missed="0" covered="1"/>
-<counter type="BRANCH" missed="0" covered="0"/>
-<counter type="LINE" missed="0" covered="1"/>
+<counter type="INSTRUCTION" missed="1" covered="3"/>
+<counter type="BRANCH" missed="1" covered="1"/>
+<counter type="LINE" missed="1" covered="3"/>
 </method>
 <method name="&lt;init&gt;" desc="()V">
 <counter type="INSTRUCTION" missed="1" covered="0"/>
 <counter type="BRANCH" missed="0" covered="0"/>
 <counter type="LINE" missed="1" covered="0"/>
 </method>
-<counter type="INSTRUCTION" missed="1" covered="1"/>
-<counter type="BRANCH" missed="0" covered="0"/>
-<counter type="LINE" missed="1" covered="1"/>
+<counter type="INSTRUCTION" missed="2" covered="3"/>
+<counter type="BRANCH" missed="1" covered="1"/>
+<counter type="LINE" missed="2" covered="3"/>
 <counter type="METHOD" missed="1" covered="1"/>
 </class>
 <sourcefile name="Main.java">
 <line nr="19" mi="1" ci="0" mb="0" cb="0"/>
-<line nr="21" mi="0" ci="1" mb="0" cb="0"/>
-<counter type="INSTRUCTION" missed="1" covered="1"/>
-<counter type="BRANCH" missed="0" covered="0"/>
-<counter type="LINE" missed="1" covered="1"/>
+<line nr="21" mi="0" ci="1" mb="1" cb="1"/>
+<line nr="22" mi="0" ci="1" mb="0" cb="0"/>
+<line nr="24" mi="1" ci="0" mb="0" cb="0"/>
+<line nr="26" mi="0" ci="1" mb="0" cb="0"/>
+<counter type="INSTRUCTION" missed="2" covered="3"/>
+<counter type="BRANCH" missed="1" covered="1"/>
+<counter type="LINE" missed="2" covered="3"/>
 </sourcefile>
-<counter type="INSTRUCTION" missed="1" covered="1"/>
-<counter type="BRANCH" missed="0" covered="0"/>
-<counter type="LINE" missed="1" covered="1"/>
+<counter type="INSTRUCTION" missed="2" covered="3"/>
+<counter type="BRANCH" missed="1" covered="1"/>
+<counter type="LINE" missed="2" covered="3"/>
 <counter type="METHOD" missed="1" covered="1"/>
 <counter type="CLASS" missed="0" covered="1"/>
 </package>
-<counter type="INSTRUCTION" missed="1" covered="1"/>
-<counter type="BRANCH" missed="0" covered="0"/>
-<counter type="LINE" missed="1" covered="1"/>
+<counter type="INSTRUCTION" missed="2" covered="3"/>
+<counter type="BRANCH" missed="1" covered="1"/>
+<counter type="LINE" missed="2" covered="3"/>
 <counter type="METHOD" missed="1" covered="1"/>
 <counter type="CLASS" missed="0" covered="1"/>
 </report>

--- a/reporter/resources/xmlIntegrationTest.xml
+++ b/reporter/resources/xmlIntegrationTest.xml
@@ -3,18 +3,18 @@
 <package name="testData/simple">
 <class name="testData/simple/Main" sourcefilename="Main.java">
 <method name="main" desc="([Ljava/lang/String;)V">
-<counter type="INSTRUCTION" missed="1" covered="3"/>
-<counter type="BRANCH" missed="1" covered="1"/>
-<counter type="LINE" missed="1" covered="3"/>
+<counter type="INSTRUCTION" missed="4" covered="6"/>
+<counter type="BRANCH" missed="3" covered="2"/>
+<counter type="LINE" missed="4" covered="6"/>
 </method>
 <method name="&lt;init&gt;" desc="()V">
 <counter type="INSTRUCTION" missed="1" covered="0"/>
 <counter type="BRANCH" missed="0" covered="0"/>
 <counter type="LINE" missed="1" covered="0"/>
 </method>
-<counter type="INSTRUCTION" missed="2" covered="3"/>
-<counter type="BRANCH" missed="1" covered="1"/>
-<counter type="LINE" missed="2" covered="3"/>
+<counter type="INSTRUCTION" missed="5" covered="6"/>
+<counter type="BRANCH" missed="3" covered="2"/>
+<counter type="LINE" missed="5" covered="6"/>
 <counter type="METHOD" missed="1" covered="1"/>
 </class>
 <sourcefile name="Main.java">
@@ -23,19 +23,25 @@
 <line nr="22" mi="0" ci="1" mb="0" cb="0"/>
 <line nr="24" mi="1" ci="0" mb="0" cb="0"/>
 <line nr="26" mi="0" ci="1" mb="0" cb="0"/>
-<counter type="INSTRUCTION" missed="2" covered="3"/>
-<counter type="BRANCH" missed="1" covered="1"/>
-<counter type="LINE" missed="2" covered="3"/>
+<line nr="28" mi="0" ci="1" mb="2" cb="1"/>
+<line nr="30" mi="0" ci="1" mb="0" cb="0"/>
+<line nr="31" mi="0" ci="1" mb="0" cb="0"/>
+<line nr="33" mi="1" ci="0" mb="0" cb="0"/>
+<line nr="34" mi="1" ci="0" mb="0" cb="0"/>
+<line nr="36" mi="1" ci="0" mb="0" cb="0"/>
+<counter type="INSTRUCTION" missed="5" covered="6"/>
+<counter type="BRANCH" missed="3" covered="2"/>
+<counter type="LINE" missed="5" covered="6"/>
 </sourcefile>
-<counter type="INSTRUCTION" missed="2" covered="3"/>
-<counter type="BRANCH" missed="1" covered="1"/>
-<counter type="LINE" missed="2" covered="3"/>
+<counter type="INSTRUCTION" missed="5" covered="6"/>
+<counter type="BRANCH" missed="3" covered="2"/>
+<counter type="LINE" missed="5" covered="6"/>
 <counter type="METHOD" missed="1" covered="1"/>
 <counter type="CLASS" missed="0" covered="1"/>
 </package>
-<counter type="INSTRUCTION" missed="2" covered="3"/>
-<counter type="BRANCH" missed="1" covered="1"/>
-<counter type="LINE" missed="2" covered="3"/>
+<counter type="INSTRUCTION" missed="5" covered="6"/>
+<counter type="BRANCH" missed="3" covered="2"/>
+<counter type="LINE" missed="5" covered="6"/>
 <counter type="METHOD" missed="1" covered="1"/>
 <counter type="CLASS" missed="0" covered="1"/>
 </report>

--- a/reporter/test/testData/simple/Main.java
+++ b/reporter/test/testData/simple/Main.java
@@ -18,6 +18,11 @@ package testData.simple;
 
 public class Main {
   public static void main(String[] args) {
+    if (args.length == 0) {
+      System.out.println("No args");
+    } else {
+      System.out.println("Get " + args.length + " args.");
+    }
     System.out.println("Hello world");
   }
 }

--- a/reporter/test/testData/simple/Main.java
+++ b/reporter/test/testData/simple/Main.java
@@ -24,5 +24,17 @@ public class Main {
       System.out.println("Get " + args.length + " args.");
     }
     System.out.println("Hello world");
+
+    switch (args.length) {
+      case 0:
+        System.out.println(1);
+        break;
+      case 1:
+        System.out.println(2);
+        break;
+      case 2:
+        System.out.println(3);
+        break;
+    }
   }
 }

--- a/src/com/intellij/rt/coverage/data/LineData.java
+++ b/src/com/intellij/rt/coverage/data/LineData.java
@@ -231,14 +231,17 @@ public class LineData implements CoverageData {
     JumpData[] jumps = myJumpsAndSwitches.getJumps();
     if (jumps != null) {
       for (JumpData jump : jumps) {
-        total++;
-        if (jump.getFalseHits() > 0 && jump.getTrueHits() > 0) covered++;
+        total += 2;
+        if (jump.getFalseHits() > 0) covered++;
+        if (jump.getTrueHits() > 0) covered++;
       }
     }
 
     SwitchData[] switches = myJumpsAndSwitches.getSwitches();
     if (switches != null) {
       for (SwitchData switchData : switches) {
+        total++;
+        if (switchData.getDefaultHits() > 0) covered++;
         for (int hit : switchData.getHits()) {
           total++;
           if (hit > 0) covered++;

--- a/src/com/intellij/rt/coverage/data/LineData.java
+++ b/src/com/intellij/rt/coverage/data/LineData.java
@@ -240,8 +240,6 @@ public class LineData implements CoverageData {
     SwitchData[] switches = myJumpsAndSwitches.getSwitches();
     if (switches != null) {
       for (SwitchData switchData : switches) {
-        total++;
-        if (switchData.getDefaultHits() > 0) covered++;
         for (int hit : switchData.getHits()) {
           total++;
           if (hit > 0) covered++;


### PR DESCRIPTION
Fix consistency in branch counting:

- 1 `switch` corresponded to several branches, while `if` corresponded to one. Now `if` consists of 2 branches, so partially covered `if` corresponds to 1 in covered branches
- Default `switch` branch is now counted
- Unloaded classes branch count is now consistent with loaded classes