### PR TITLE
Replace ClassLoader.getResourceAsStream call by class files iteration

### DIFF
--- a/reporter/src/com/intellij/rt/coverage/report/data/Module.java
+++ b/reporter/src/com/intellij/rt/coverage/report/data/Module.java
@@ -108,18 +108,9 @@ public class Module {
 
     @Override
     protected Collection<ClassPathEntry> getClassPathEntries() {
-      final URL[] urls = new URL[myOutputRoots.size()];
-      for (int i = 0; i < myOutputRoots.size(); i++) {
-        try {
-          urls[i] = myOutputRoots.get(i).toURI().toURL();
-        } catch (MalformedURLException e) {
-          throw new RuntimeException(e);
-        }
-      }
-      final URLClassLoader loader = new URLClassLoader(urls);
       final List<ClassPathEntry> entries = new ArrayList<ClassPathEntry>();
       for (File outputRoot : myOutputRoots) {
-        entries.add(new ClassPathEntry(outputRoot.getAbsolutePath(), loader));
+        entries.add(new ClassPathEntry(outputRoot.getAbsolutePath()));
       }
       return entries;
     }

--- a/test-kotlin/build.gradle
+++ b/test-kotlin/build.gradle
@@ -9,6 +9,7 @@ repositories {
 sourceSets {
     main.java.srcDirs = []
     test.java.srcDirs = [file('src')]
+    jmh.java.srcDirs = [file('jmh')]
 }
 
 targetCompatibility = "1.8"
@@ -27,6 +28,11 @@ dependencies {
 
     testImplementation(fileTree(project(":benchmarks").file("lib")))
 
+    jmhCompile("org.openjdk.jmh:jmh-core:1.32")
+    jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.32")
+    jmhCompile(project(path: ":instrumentation", configuration: "archives"))
+    jmhCompile(project(":"))
+
     testImplementation("net.bytebuddy:byte-buddy:1.11.12")
     testImplementation("net.bytebuddy:byte-buddy-agent:1.11.12")
 
@@ -36,5 +42,25 @@ dependencies {
 test {
     filter {
         excludeTestsMatching("testData.*")
+    }
+}
+
+task runBenchmark(type: JavaExec) {
+    configureBenchmark it as JavaExec
+}
+
+def configureBenchmark(JavaExec benchmark) {
+    benchmark.with {
+        dependsOn "jmhClasses"
+        main = 'org.openjdk.jmh.Main'
+        doFirst {
+            classpath = sourceSets.jmh.runtimeClasspath
+            args = [
+                // fail-on-error
+                '-foe', 'true',
+                // benchmarks
+                'com\\.intellij\\.rt\\.coverage\\.jmh\\.AppendUnloadedBenchmark.*',
+            ]
+        }
     }
 }

--- a/test-kotlin/jmh/com/intellij/rt/coverage/jmh/AppendUnloadedBenchmark.java
+++ b/test-kotlin/jmh/com/intellij/rt/coverage/jmh/AppendUnloadedBenchmark.java
@@ -51,11 +51,12 @@ public class AppendUnloadedBenchmark {
   @Benchmark
   public int unloaded() throws Exception {
     final ProjectData projectData = ProjectData.createProjectData(new File("test.ic"), null, false, isSampling, Collections.<Pattern>emptyList(), Collections.<Pattern>emptyList(), null);
-    final Collection<ClassEntry> matchedClasses = createClassFinder().findMatchedClasses();
-
-    for (ClassEntry classEntry : matchedClasses) {
-      processClassEntry(projectData, classEntry);
-    }
+    createClassFinder().iterateMatchedClasses(new ClassEntry.Consumer() {
+      @Override
+      public void consume(ClassEntry classEntry) {
+        processClassEntry(projectData, classEntry);
+      }
+    });
     System.out.println(projectData.getClassesNumber());
     return projectData.getClassesNumber();
   }

--- a/test-kotlin/jmh/com/intellij/rt/coverage/jmh/AppendUnloadedBenchmark.java
+++ b/test-kotlin/jmh/com/intellij/rt/coverage/jmh/AppendUnloadedBenchmark.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2000-2021 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.jmh;
+
+import com.intellij.rt.coverage.data.*;
+import com.intellij.rt.coverage.instrumentation.SourceLineCounter;
+import com.intellij.rt.coverage.util.ErrorReporter;
+import com.intellij.rt.coverage.util.LinesUtil;
+import com.intellij.rt.coverage.util.StringsPool;
+import com.intellij.rt.coverage.util.classFinder.ClassEntry;
+import com.intellij.rt.coverage.util.classFinder.ClassFinder;
+import org.jetbrains.coverage.gnu.trove.TIntObjectHashMap;
+import org.jetbrains.coverage.gnu.trove.TIntObjectProcedure;
+import org.jetbrains.coverage.org.objectweb.asm.ClassReader;
+import org.openjdk.jmh.annotations.*;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+@BenchmarkMode(Mode.SingleShotTime)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+public class AppendUnloadedBenchmark {
+  final boolean isSampling = false;
+  final boolean calculateSource = true;
+
+  @Benchmark
+  public int unloaded() throws Exception {
+    final ProjectData projectData = ProjectData.createProjectData(new File("test.ic"), null, false, isSampling, Collections.<Pattern>emptyList(), Collections.<Pattern>emptyList(), null);
+    final Collection<ClassEntry> matchedClasses = createClassFinder().findMatchedClasses();
+
+    for (ClassEntry classEntry : matchedClasses) {
+      processClassEntry(projectData, classEntry);
+    }
+    System.out.println(projectData.getClassesNumber());
+    return projectData.getClassesNumber();
+  }
+
+  private void processClassEntry(ProjectData projectData, ClassEntry classEntry) {
+    ClassData cd = projectData.getClassData(StringsPool.getFromPool(classEntry.getClassName()));
+    if (cd != null && cd.getLines() != null) return;
+    try {
+      final InputStream classInputStream = classEntry.getClassInputStream();
+      if (classInputStream == null) return;
+      ClassReader reader = new ClassReader(classInputStream);
+      classInputStream.close();
+      if (calculateSource) {
+        cd = projectData.getOrCreateClassData(StringsPool.getFromPool(classEntry.getClassName()));
+      }
+      SourceLineCounter slc = new SourceLineCounter(cd, calculateSource ? projectData : null, !isSampling);
+      reader.accept(slc, 0);
+      if (slc.isEnum() || slc.getNSourceLines() > 0) { // ignore classes without executable code
+        final TIntObjectHashMap<LineData> lines = new TIntObjectHashMap<LineData>(4, 0.99f);
+        final int[] maxLine = new int[]{1};
+        final ClassData classData = projectData.getOrCreateClassData(StringsPool.getFromPool(classEntry.getClassName()));
+        slc.getSourceLines().forEachEntry(new TIntObjectProcedure<String>() {
+          public boolean execute(int line, String methodSig) {
+            final LineData ld = new LineData(line, StringsPool.getFromPool(methodSig));
+            lines.put(line, ld);
+            if (line > maxLine[0]) maxLine[0] = line;
+            classData.registerMethodSignature(ld);
+            ld.setStatus(LineCoverage.NONE);
+            return true;
+          }
+        });
+        final TIntObjectHashMap<JumpsAndSwitches> jumpsPerLine = slc.getJumpsPerLine();
+        if (jumpsPerLine != null) {
+          jumpsPerLine.forEachEntry(new TIntObjectProcedure<JumpsAndSwitches>() {
+            public boolean execute(int line, JumpsAndSwitches jumpData) {
+              final LineData lineData = lines.get(line);
+              if (lineData != null) {
+                lineData.setJumpsAndSwitches(jumpData);
+                lineData.fillArrays();
+              }
+              return true;
+            }
+          });
+        }
+        classData.setLines(LinesUtil.calcLineArray(maxLine[0], lines));
+      }
+    } catch (Throwable e) {
+      ErrorReporter.reportError("Failed to process unloaded class: " + classEntry.getClassName() + ", error: " + e.getMessage(), e);
+    }
+  }
+
+  private ClassFinder createClassFinder() {
+    final String absolutePath = "<Directory with output roots>";
+    final Pattern includePattern = Pattern.compile("com\\..*");
+    final ClassFinder finder = new ClassFinder(Collections.singletonList(includePattern), Collections.<Pattern>emptyList());
+    final File dir = new File(absolutePath);
+    final File[] files = dir.listFiles();
+    for (File child : files) {
+      try {
+        final URL url = child.toURI().toURL();
+        finder.addClassLoader(new URLClassLoader(new URL[]{url}));
+      } catch (MalformedURLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    return finder;
+  }
+
+  public static void main(String[] args) throws Exception {
+    AppendUnloadedBenchmark b = new AppendUnloadedBenchmark();
+    b.unloaded();
+  }
+}

--- a/util/src/com/intellij/rt/coverage/util/CoverageIOUtil.java
+++ b/util/src/com/intellij/rt/coverage/util/CoverageIOUtil.java
@@ -282,10 +282,18 @@ public class CoverageIOUtil {
     return new DataOutputStream(new BufferedOutputStream(new FileOutputStream(file)));
   }
 
-  public static void close(DataOutputStream out) {
+  public static void close(OutputStream out) {
     if (out != null) {
       try {
         out.close();
+      } catch (IOException ignored) {}
+    }
+  }
+
+  public static void close(InputStream in) {
+    if (in != null) {
+      try {
+        in.close();
       } catch (IOException ignored) {}
     }
   }

--- a/util/src/com/intellij/rt/coverage/util/classFinder/ClassEntry.java
+++ b/util/src/com/intellij/rt/coverage/util/classFinder/ClassEntry.java
@@ -16,56 +16,38 @@
 
 package com.intellij.rt.coverage.util.classFinder;
 
-import com.intellij.rt.coverage.util.ClassNameUtil;
-
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
  * @author Pavel.Sher
  */
-public class ClassEntry {
+public abstract class ClassEntry {
   private final String myClassName;
-  private final ClassLoader myClassLoader;
 
-  public ClassEntry(final String className, final ClassLoader classLoader) {
+  public ClassEntry(final String className) {
     myClassName = className;
-    myClassLoader = classLoader;
   }
 
   public String getClassName() {
     return myClassName;
   }
 
-  public InputStream getClassInputStream() {
-    String resourceName = ClassNameUtil.convertToInternalName(myClassName) + ".class";
-    InputStream is = getResourceStream(resourceName);
-    if (is != null) return is;
-    return getResourceStream("/" + resourceName);
-  }
-
-  private InputStream getResourceStream(final String resourceName) {
-    if (myClassLoader == null) {
-      return getClass().getResourceAsStream(resourceName);
-    }
-
-    return myClassLoader.getResourceAsStream(resourceName);
-  }
+  public abstract InputStream getClassInputStream() throws IOException;
 
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
     final ClassEntry that = (ClassEntry) o;
-
-    if (myClassLoader != null ? !myClassLoader.equals(that.myClassLoader) : that.myClassLoader != null) return false;
-    if (!myClassName.equals(that.myClassName)) return false;
-
-    return true;
+    return myClassName.equals(that.myClassName);
   }
 
   public int hashCode() {
-    int result = myClassName.hashCode();
-    result = 31 * result + (myClassLoader != null ? myClassLoader.hashCode() : 0);
-    return result;
+    return myClassName.hashCode();
+  }
+
+  public interface Consumer {
+    void consume(ClassEntry classEntry);
   }
 }

--- a/util/src/com/intellij/rt/coverage/util/classFinder/ClassFinder.java
+++ b/util/src/com/intellij/rt/coverage/util/classFinder/ClassFinder.java
@@ -54,16 +54,14 @@ public class ClassFinder {
     }
   }
 
-  public Collection<ClassEntry> findMatchedClasses() {
-    Set<ClassEntry> classes = new HashSet<ClassEntry>();
+  public void iterateMatchedClasses(ClassEntry.Consumer consumer) {
     for (ClassPathEntry entry : getClassPathEntries()) {
       try {
-        classes.addAll(entry.getClassesIterator(myIncludePatterns, myExcludePatterns));
+        entry.iterateMatchedClasses(myIncludePatterns, myExcludePatterns, consumer);
       } catch (IOException e) {
         ErrorReporter.reportError("Error during iterating classes.", e);
       }
     }
-    return classes;
   }
 
   // Overriden in IntelliJ
@@ -87,7 +85,7 @@ public class ClassFinder {
           if (!"file".equals(url.getProtocol())) continue;
 
           String path = fixPath(url.getPath());
-          result.add(new ClassPathEntry(path, cl));
+          result.add(new ClassPathEntry(path));
         }
       } catch (Exception e) {
         ErrorReporter.reportError("Exception occurred on trying collect ClassPath URLs. One of possible reasons is shutting down " +
@@ -118,7 +116,7 @@ public class ClassFinder {
     String[] entries = classPath.split(System.getProperty("path.separator"));
     Set<ClassPathEntry> result = new HashSet<ClassPathEntry>();
     for (String entry : entries) {
-      result.add(new ClassPathEntry(entry, null));
+      result.add(new ClassPathEntry(entry));
     }
     return result;
   }


### PR DESCRIPTION
ClassLoader.getResourceAsStream call slows down processing unloaded classes, but we can load bytecode directly from file/zip entry while iterating over classes output.

Benchmark results for 83958 classes
```
Benchmark                         Mode  Cnt  Score   Error  Units
ClassLoader.getResourceAsStream     ss   10  9.458 ± 0.116   s/op
Iterate over class files            ss   10  6.600 ± 0.102   s/op
```