### PR TITLE
IDEA-169757 : support charset for html file encoding

### DIFF
--- a/kover/kover-cli/README.md
+++ b/kover/kover-cli/README.md
@@ -34,6 +34,7 @@ Allows you to generate HTML and XML reports.
 | --include <class-name>                | filter to include classes, wildcards `*` and `?` are acceptable                                         |          |    +     |
 | --src <sources-path>                  | location of the source files root                                                                       |    +     |    +     |
 | --title <html-title>                  | title in the HTML report                                                                                |          |          |
+| --charset <html-charset>              | charset in the HTML report                                                                              |          |          |
 | --xml <xml-file-path>                 | generate a XML report in the specified path                                                             |          |          |
 
 ## Off-line instrumentation

--- a/kover/kover-cli/src/main/kotlin/kotlinx/kover/cli/commands/ReportCommand.kt
+++ b/kover/kover-cli/src/main/kotlin/kotlinx/kover/cli/commands/ReportCommand.kt
@@ -54,6 +54,9 @@ internal class ReportCommand : Command {
     @Option(name = "--title", usage = "title in the HTML report", metaVar = "<html-title>")
     private var htmlTitle: String? = null
 
+    @Option(name = "--charset", usage = "charset in the HTML report", metaVar = "<html-charset>")
+    private var charset: String? = null
+
     @Option(
         name = "--include",
         usage = "filter to include classes, wildcards `*` and `?` are acceptable",
@@ -104,7 +107,7 @@ internal class ReportCommand : Command {
         }
         if (htmlDir != null) {
             try {
-                reporter.createHTMLReport(htmlDir, htmlTitle)
+                reporter.createHTMLReport(htmlDir, htmlTitle, charset)
             } catch (e: IOException) {
                 fail = true
                 error.println("HTML generation failed: " + e.message)

--- a/reporter/src/com/intellij/rt/coverage/report/Main.java
+++ b/reporter/src/com/intellij/rt/coverage/report/Main.java
@@ -51,7 +51,7 @@ public class Main {
       final File htmlDir = args.htmlDir;
       if (htmlDir != null) {
         try {
-          reporter.createHTMLReport(htmlDir, args.title);
+          reporter.createHTMLReport(htmlDir, args.title, args.charset);
         } catch (IOException e) {
           fail = true;
           System.err.println("HTML generation failed.");

--- a/reporter/src/com/intellij/rt/coverage/report/Reporter.java
+++ b/reporter/src/com/intellij/rt/coverage/report/Reporter.java
@@ -56,7 +56,10 @@ public class Reporter {
     builder.setReportDir(htmlDir);
     if (builder instanceof HTMLReportBuilderImpl) {
       ((HTMLReportBuilderImpl) builder).setReportTitle(title);
-      ((HTMLReportBuilderImpl) builder).setCharset(charset);
+
+      if (charset != null) {
+        ((HTMLReportBuilderImpl) builder).setCharset(charset);
+      }
     }
     final SourceCodeProvider sourceCodeProvider = new DirectorySourceCodeProvider(myLoad.getProjectData(), myLoad.getSources());
     builder.generateReport(new IDEACoverageData(myLoad.getProjectData(), sourceCodeProvider));

--- a/reporter/src/com/intellij/rt/coverage/report/Reporter.java
+++ b/reporter/src/com/intellij/rt/coverage/report/Reporter.java
@@ -50,12 +50,13 @@ public class Reporter {
     }
   }
 
-  public void createHTMLReport(File htmlDir, String title) throws IOException {
+  public void createHTMLReport(File htmlDir, String title, String charset) throws IOException {
     htmlDir.mkdirs();
     final HTMLReportBuilder builder = ReportBuilderFactory.createHTMLReportBuilderForKover();
     builder.setReportDir(htmlDir);
     if (builder instanceof HTMLReportBuilderImpl) {
       ((HTMLReportBuilderImpl) builder).setReportTitle(title);
+      ((HTMLReportBuilderImpl) builder).setCharset(charset);
     }
     final SourceCodeProvider sourceCodeProvider = new DirectorySourceCodeProvider(myLoad.getProjectData(), myLoad.getSources());
     builder.generateReport(new IDEACoverageData(myLoad.getProjectData(), sourceCodeProvider));

--- a/reporter/src/com/intellij/rt/coverage/report/ReporterArgs.java
+++ b/reporter/src/com/intellij/rt/coverage/report/ReporterArgs.java
@@ -114,7 +114,7 @@ public class ReporterArgs {
         ? args.getString(FORMAT_TAG)
         : RAW_FORMAT;
     final String title = args.has(TITLE_TAG) ? args.getString(TITLE_TAG) : "";
-    final String charset = args.has(CHARSET_TAG) ? args.getString(CHARSET_TAG) : "";
+    final String charset = args.has(CHARSET_TAG) ? args.getString(CHARSET_TAG) : null;
     final List<Module> moduleList = parseModules(args);
     final List<BinaryReport> reportList = parseReports(args);
     final Filters filters = parseFilters(args);

--- a/reporter/src/com/intellij/rt/coverage/report/ReporterArgs.java
+++ b/reporter/src/com/intellij/rt/coverage/report/ReporterArgs.java
@@ -46,6 +46,7 @@ public class ReporterArgs {
   static final String XML_FILE_TAG = "xml";
   static final String HTML_DIR_TAG = "html";
   public static final String TITLE_TAG = "title";
+  public static final String CHARSET_TAG = "charset";
   static final String MODULES_TAG = "modules";
   static final String REPORTS_TAG = "reports";
   static final String IC_FILE_TAG = "ic";
@@ -60,18 +61,21 @@ public class ReporterArgs {
 
   public final String format;
   public final String title;
+  public final String charset;
+
   public final List<BinaryReport> reports;
   public final List<Module> modules;
   public final File xmlFile;
   public final File htmlDir;
   public final Filters filters;
 
-  ReporterArgs(String format, String title,
+  ReporterArgs(String format, String title, String charset,
                List<BinaryReport> reportList, List<Module> modules,
                File xmlFile, File htmlDir,
                Filters filters) {
     this.format = format;
     this.title = title;
+    this.charset = charset;
     this.reports = reportList;
     this.modules = modules;
     this.xmlFile = xmlFile;
@@ -110,6 +114,7 @@ public class ReporterArgs {
         ? args.getString(FORMAT_TAG)
         : RAW_FORMAT;
     final String title = args.has(TITLE_TAG) ? args.getString(TITLE_TAG) : "";
+    final String charset = args.has(CHARSET_TAG) ? args.getString(CHARSET_TAG) : "";
     final List<Module> moduleList = parseModules(args);
     final List<BinaryReport> reportList = parseReports(args);
     final Filters filters = parseFilters(args);
@@ -117,7 +122,7 @@ public class ReporterArgs {
     final File xmlFile = args.has(XML_FILE_TAG) ? new File(args.getString(XML_FILE_TAG)) : null;
     final File htmlDir = args.has(HTML_DIR_TAG) ? new File(args.getString(HTML_DIR_TAG)) : null;
 
-    return new ReporterArgs(format, title, reportList, moduleList, xmlFile, htmlDir, filters);
+    return new ReporterArgs(format, title, charset, reportList, moduleList, xmlFile, htmlDir, filters);
   }
 
   public static List<BinaryReport> parseReports(JSONObject args) {

--- a/reporter/test/com/intellij/rt/coverage/report/HTMLTest.java
+++ b/reporter/test/com/intellij/rt/coverage/report/HTMLTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 
 public class HTMLTest {
   private static final String DEFAULT_TITLE = "TITLE";
+  private static final String DEFAULT_CHARSET = "UTF-8";
 
   @Test
   public void testSimple() throws Throwable {
@@ -93,7 +94,7 @@ public class HTMLTest {
     final BinaryReport report = TestUtils.runTest(patterns, className);
     final File htmlDir = createHtmlDir(report.getDataFile());
     TestUtils.clearLogFile(new File("."));
-    TestUtils.createRawReporter(report, patterns).createHTMLReport(htmlDir, DEFAULT_TITLE);
+    TestUtils.createRawReporter(report, patterns).createHTMLReport(htmlDir, DEFAULT_TITLE, DEFAULT_CHARSET);
     TestUtils.checkLogFile(new File("."));
     return htmlDir;
   }


### PR DESCRIPTION
As next step for [IDEA-169757: Code coverage report: html file encoding](https://youtrack.jetbrains.com/issue/IDEA-169757)  and https://github.com/JetBrains/coverage-report/pull/3, we need to pass charset arguments to html report generate engine.

next step
- [Kotlin/kotlinx-kover](https://github.com/Kotlin/kotlinx-kover) : Modify interface to inject charset from configuration, and pass it to args

Reviews will be of great help to next step i'm working on 😄 thanks, bro :)