### PR TITLE
New: Add `INVOKEDYNAMIC` instrumentation.

### DIFF
--- a/instrumentation/java7-utils/src/com/intellij/rt/coverage/util/IndyUtils.java
+++ b/instrumentation/java7-utils/src/com/intellij/rt/coverage/util/IndyUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.util;
+
+import com.intellij.rt.coverage.instrumentation.CoverageRuntime;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+@SuppressWarnings("unused")
+public class IndyUtils {
+  public static CallSite getHits(MethodHandles.Lookup lookup, String name, MethodType type, String className) {
+    return constant(CoverageRuntime.getHits(className));
+  }
+
+  public static CallSite getHitsMask(MethodHandles.Lookup lookup, String name, MethodType type, String className) {
+    return constant(CoverageRuntime.getHitsMask(className));
+  }
+
+  public static CallSite getTraceMask(MethodHandles.Lookup lookup, String name, MethodType type, String className) {
+    return constant(CoverageRuntime.getTraceMask(className));
+  }
+
+  public static CallSite loadClassData(MethodHandles.Lookup lookup, String name, MethodType type, String className) {
+    return constant(CoverageRuntime.loadClassData(className));
+  }
+  
+  private static CallSite constant(Object cst) {
+    return new ConstantCallSite(MethodHandles.constant(Object.class, cst));
+  }
+}

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/InstrumentationUtils.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/InstrumentationUtils.java
@@ -68,6 +68,10 @@ public class InstrumentationUtils {
     return OptionsUtil.CONDY_ENABLED && getBytecodeVersion(cr) >= Opcodes.V11;
   }
 
+  public static boolean isIndyEnabled(ClassReader cr) {
+    return OptionsUtil.INDY_ENABLED && getBytecodeVersion(cr) >= Opcodes.V1_7;
+  }
+
   public static boolean isIntConstLoading(int opcode) {
     return Opcodes.ICONST_M1 <= opcode && opcode <= Opcodes.ICONST_5
         || opcode == Opcodes.BIPUSH

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/dataAccess/DataAccessUtil.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/dataAccess/DataAccessUtil.java
@@ -21,6 +21,7 @@ import com.intellij.rt.coverage.instrumentation.InstrumentationUtils;
 import com.intellij.rt.coverage.instrumentation.data.InstrumentationData;
 import com.intellij.rt.coverage.instrumentation.data.Key;
 import com.intellij.rt.coverage.util.OptionsUtil;
+import org.jetbrains.coverage.org.objectweb.asm.ClassReader;
 
 public class DataAccessUtil {
   public static final String HITS_ARRAY_TYPE = "[I";
@@ -31,20 +32,35 @@ public class DataAccessUtil {
   public static CoverageDataAccess createTestTrackingDataAccess(InstrumentationData data, boolean isArray) {
     String className = data.get(Key.CLASS_NAME);
     boolean fieldInstrumentation = OptionsUtil.FIELD_INSTRUMENTATION_ENABLED;
-    if (fieldInstrumentation && InstrumentationUtils.isCondyEnabled(data.get(Key.CLASS_READER))) {
-      CoverageDataAccess.Init init = isArray ? createTestTrackingArrayCondyInit(className) : createTestTrackingCondyInit(className);
-      return new CondyCoverageDataAccess(init);
+    if (fieldInstrumentation) {
+      ClassReader reader = data.get(Key.CLASS_READER);
+      if (InstrumentationUtils.isCondyEnabled(reader)) {
+        CoverageDataAccess.Init init = isArray ? createTestTrackingArrayCondyInit(className) : createTestTrackingCondyInit(className);
+        return new CondyCoverageDataAccess(init);
+      } else if (InstrumentationUtils.isIndyEnabled(reader)) {
+        CoverageDataAccess.Init init = isArray ? createTestTrackingArrayIndyInit(className) : createTestTrackingIndyInit(className);
+        return new IndyCoverageDataAccess(init);
+      } else {
+        CoverageDataAccess.Init init = isArray ? createTestTrackingArrayInit(className) : createTestTrackingInit(className, false);
+        return new FieldCoverageDataAccess(reader, className, init);
+      }
     } else {
-      CoverageDataAccess.Init init = isArray ? createTestTrackingArrayInit(className) : createTestTrackingInit(className, !fieldInstrumentation);
-      return fieldInstrumentation
-          ? new FieldCoverageDataAccess(data.get(Key.CLASS_READER), className, init)
-          : new NameCoverageDataAccess(init);
+      CoverageDataAccess.Init init = isArray ? createTestTrackingArrayInit(className) : createTestTrackingInit(className, true);
+      return new NameCoverageDataAccess(init);
     }
   }
 
   private static CoverageDataAccess.Init createTestTrackingInit(String className, boolean needCache) {
     return new CoverageDataAccess.Init("__$classData$__", InstrumentationUtils.OBJECT_TYPE, CoverageRuntime.COVERAGE_RUNTIME_OWNER,
         needCache ? "loadClassDataCached" : "loadClassData", "(Ljava/lang/String;)" + InstrumentationUtils.OBJECT_TYPE, new Object[]{className});
+  }
+
+  private static CoverageDataAccess.Init createTestTrackingIndyInit(String className) {
+    return new CoverageDataAccess.Init(
+        "__$classData$__", InstrumentationUtils.OBJECT_TYPE, "com/intellij/rt/coverage/util/IndyUtils", "loadClassData",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;",
+        new Object[]{className}
+    );
   }
 
   private static CoverageDataAccess.Init createTestTrackingCondyInit(String className) {
@@ -55,6 +71,14 @@ public class DataAccessUtil {
   private static CoverageDataAccess.Init createTestTrackingArrayInit(String className) {
     return new CoverageDataAccess.Init("__$traceMask$__", TEST_MASK_ARRAY_TYPE, CoverageRuntime.COVERAGE_RUNTIME_OWNER,
         "getTraceMask", "(Ljava/lang/String;)" + TEST_MASK_ARRAY_TYPE, new Object[]{className});
+  }
+
+  private static CoverageDataAccess.Init createTestTrackingArrayIndyInit(String className) {
+    return new CoverageDataAccess.Init(
+        "__$traceMask$__", TEST_MASK_ARRAY_TYPE, "com/intellij/rt/coverage/util/IndyUtils", "getTraceMask",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;",
+        new Object[]{className}
+    );
   }
 
   private static CoverageDataAccess.Init createTestTrackingArrayCondyInit(String className) {

--- a/instrumentation/src/com/intellij/rt/coverage/instrumentation/dataAccess/IndyCoverageDataAccess.java
+++ b/instrumentation/src/com/intellij/rt/coverage/instrumentation/dataAccess/IndyCoverageDataAccess.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2022 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.instrumentation.dataAccess;
+
+import com.intellij.rt.coverage.instrumentation.InstrumentationUtils;
+import org.jetbrains.coverage.org.objectweb.asm.*;
+
+/**
+ * Loads coverage data using an INVOKEDYNAMIC (indy).
+ * After the first invocation, the array becomes bound to the call-site and no lookup is necessary.
+ * Supported for class files version 7+.
+ */
+public class IndyCoverageDataAccess extends CoverageDataAccess {
+  private final Handle myBsm;
+
+  public IndyCoverageDataAccess(Init init) {
+    super(init);
+    myBsm = new Handle(Opcodes.H_INVOKESTATIC, init.initOwner, init.initName, init.initDesc, false);
+  }
+
+  @Override
+  public void onMethodStart(MethodVisitor mv, int localVariable) {
+    mv.visitInvokeDynamicInsn(
+      myInit.name,
+      "()" + InstrumentationUtils.OBJECT_TYPE,
+      myBsm,
+      myInit.params
+    );
+    if (!InstrumentationUtils.OBJECT_TYPE.equals(myInit.desc)) {
+      mv.visitTypeInsn(Opcodes.CHECKCAST, myInit.desc);
+    }
+    mv.visitVarInsn(Opcodes.ASTORE, localVariable);
+  }
+}

--- a/offline-runtime/java7-utils/src/com/intellij/rt/coverage/offline/IndyUtils.java
+++ b/offline-runtime/java7-utils/src/com/intellij/rt/coverage/offline/IndyUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2024 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intellij.rt.coverage.offline;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+@SuppressWarnings("unused")
+public class IndyUtils {
+  public static CallSite getOrCreateHits(MethodHandles.Lookup lookup, String name, MethodType type, String className, int length) {
+    return constant(RawProjectInit.getOrCreateHits(className, length));
+  }
+
+  public static CallSite getOrCreateHitsMask(MethodHandles.Lookup lookup, String name, MethodType type, String className, int length) {
+    return constant(RawProjectInit.getOrCreateHitsMask(className, length));
+  }
+
+  private static CallSite constant(Object cst) {
+    return new ConstantCallSite(MethodHandles.constant(Object.class, cst));
+  }
+}

--- a/reporter/src/com/intellij/rt/coverage/instrument/OfflineCoverageTransformer.java
+++ b/reporter/src/com/intellij/rt/coverage/instrument/OfflineCoverageTransformer.java
@@ -51,6 +51,19 @@ public class OfflineCoverageTransformer extends CoverageTransformer {
   }
 
   @Override
+  protected CoverageDataAccess.Init createIndyInit(String className, ClassReader cr) {
+    final int length = getRequiredArrayLength(cr);
+    boolean calculateHits = myProjectContext.getOptions().isCalculateHits;
+    String arrayType = calculateHits ? DataAccessUtil.HITS_ARRAY_TYPE : DataAccessUtil.MASK_ARRAY_TYPE;
+    String methodName = calculateHits ? "getOrCreateHits" : "getOrCreateHitsMask";
+    return new CoverageDataAccess.Init(
+        "__$hits$__", arrayType, "com/intellij/rt/coverage/offline/IndyUtils", methodName,
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;I)Ljava/lang/invoke/CallSite;",
+        new Object[]{className, length}
+    );
+  }
+
+  @Override
   protected CoverageDataAccess.Init createCondyInit(String className, ClassReader cr) {
     final int length = getRequiredArrayLength(cr);
     boolean calculateHits = myProjectContext.getOptions().isCalculateHits;

--- a/src/com/intellij/rt/coverage/util/OptionsUtil.java
+++ b/src/com/intellij/rt/coverage/util/OptionsUtil.java
@@ -22,6 +22,7 @@ public class OptionsUtil {
           && "true".equals(System.getProperty("idea.new.tracing.coverage", "true"));
   public static final boolean NEW_TEST_TRACKING_ENABLED = "true".equals(System.getProperty("idea.new.test.tracking.coverage", "true"));
   public static boolean CONDY_ENABLED = "true".equals(System.getProperty("coverage.condy.enable", "true"));
+  public static boolean INDY_ENABLED = "true".equals(System.getProperty("coverage.indy.enable", "true"));
   public static final boolean INSTRUCTIONS_COVERAGE_ENABLED = "true".equals(System.getProperty("coverage.instructions.enable", "false"));
   public static boolean CALCULATE_HITS_COUNT = "true".equals(System.getProperty("idea.coverage.calculate.hits", "false"));
   public static boolean IGNORE_LOCAL_FUNCTIONS_IN_IGNORED_METHODS = "true".equals(System.getProperty("idea.coverage.ignore.local.functions.in.ignored.methods", "true"));

--- a/test-kotlin/test-sources/resources/bytecode/simple/branches/branch_indy.txt
+++ b/test-kotlin/test-sources/resources/bytecode/simple/branches/branch_indy.txt
@@ -1,0 +1,128 @@
+// access flags 0x31
+public final class testData/simple/branches/MyBranchedClass {
+
+  // compiled from: test.kt
+
+
+  // access flags 0x1
+  public <init>()V
+    INVOKEDYNAMIC __$hits$__()Ljava/lang/Object; [
+      // handle kind 0x6 : INVOKESTATIC
+      com/intellij/rt/coverage/util/IndyUtils.getHitsMask(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "testData.simple.branches.MyBranchedClass"
+    ]
+    CHECKCAST [Z
+    ASTORE 1
+   L0
+    LINENUMBER 22 L0
+    ALOAD 1
+    ICONST_0
+    ICONST_1
+    BASTORE
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+   L1
+    LOCALVARIABLE this LtestData/simple/branches/MyBranchedClass; L0 L1 0
+    LOCALVARIABLE __$coverage_local$__ [Z L0 L1 1
+    MAXSTACK = 3
+    MAXLOCALS = 2
+
+  // access flags 0x11
+  public final foo(I)V
+    INVOKEDYNAMIC __$hits$__()Ljava/lang/Object; [
+      // handle kind 0x6 : INVOKESTATIC
+      com/intellij/rt/coverage/util/IndyUtils.getHitsMask(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "testData.simple.branches.MyBranchedClass"
+    ]
+    CHECKCAST [Z
+    ASTORE 2
+   L0
+    LINENUMBER 24 L0
+    ALOAD 2
+    ICONST_1
+    ICONST_1
+    BASTORE
+    ILOAD 1
+    IFGE L1
+    GOTO L2
+   L1
+    ALOAD 2
+    ICONST_2
+    ICONST_1
+    BASTORE
+    GOTO L3
+   L2
+    ALOAD 2
+    ICONST_3
+    ICONST_1
+    BASTORE
+   L4
+    LINENUMBER 25 L4
+    ALOAD 2
+    ICONST_4
+    ICONST_1
+    BASTORE
+    LDC "LE"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+    GOTO L5
+   L3
+    LINENUMBER 26 L3
+    ALOAD 2
+    ICONST_5
+    ICONST_1
+    BASTORE
+   L6
+   FRAME APPEND [[Z]
+    ILOAD 1
+    IFNE L7
+    GOTO L8
+   L7
+    ALOAD 2
+    BIPUSH 6
+    ICONST_1
+    BASTORE
+    GOTO L9
+   L8
+    ALOAD 2
+    BIPUSH 7
+    ICONST_1
+    BASTORE
+   L10
+    LINENUMBER 27 L10
+    ALOAD 2
+    BIPUSH 8
+    ICONST_1
+    BASTORE
+    LDC "EQ"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+    GOTO L5
+   L9
+    LINENUMBER 29 L9
+    ALOAD 2
+    BIPUSH 9
+    ICONST_1
+    BASTORE
+   L11
+   FRAME SAME
+    LDC "GE"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+   L5
+    LINENUMBER 31 L5
+   FRAME SAME
+    RETURN
+   L12
+    LOCALVARIABLE this LtestData/simple/branches/MyBranchedClass; L0 L12 0
+    LOCALVARIABLE value I L0 L12 1
+    LOCALVARIABLE __$coverage_local$__ [Z L0 L12 2
+    MAXSTACK = 3
+    MAXLOCALS = 3
+}

--- a/test-kotlin/test-sources/resources/bytecode/simple/branches/branch_indy_with_hits.txt
+++ b/test-kotlin/test-sources/resources/bytecode/simple/branches/branch_indy_with_hits.txt
@@ -1,0 +1,158 @@
+// access flags 0x31
+public final class testData/simple/branches/MyBranchedClass {
+
+  // compiled from: test.kt
+
+
+  // access flags 0x1
+  public <init>()V
+    INVOKEDYNAMIC __$hits$__()Ljava/lang/Object; [
+      // handle kind 0x6 : INVOKESTATIC
+      com/intellij/rt/coverage/util/IndyUtils.getHits(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "testData.simple.branches.MyBranchedClass"
+    ]
+    CHECKCAST [I
+    ASTORE 1
+   L0
+    LINENUMBER 22 L0
+    ALOAD 1
+    ICONST_0
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+   L1
+    LOCALVARIABLE this LtestData/simple/branches/MyBranchedClass; L0 L1 0
+    LOCALVARIABLE __$coverage_local$__ [I L0 L1 1
+    MAXSTACK = 4
+    MAXLOCALS = 2
+
+  // access flags 0x11
+  public final foo(I)V
+    INVOKEDYNAMIC __$hits$__()Ljava/lang/Object; [
+      // handle kind 0x6 : INVOKESTATIC
+      com/intellij/rt/coverage/util/IndyUtils.getHits(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "testData.simple.branches.MyBranchedClass"
+    ]
+    CHECKCAST [I
+    ASTORE 2
+   L0
+    LINENUMBER 24 L0
+    ALOAD 2
+    ICONST_1
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    ILOAD 1
+    IFGE L1
+    GOTO L2
+   L1
+    ALOAD 2
+    ICONST_2
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    GOTO L3
+   L2
+    ALOAD 2
+    ICONST_3
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+   L4
+    LINENUMBER 25 L4
+    ALOAD 2
+    ICONST_4
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    LDC "LE"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+    GOTO L5
+   L3
+    LINENUMBER 26 L3
+    ALOAD 2
+    ICONST_5
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+   L6
+   FRAME APPEND [[I]
+    ILOAD 1
+    IFNE L7
+    GOTO L8
+   L7
+    ALOAD 2
+    BIPUSH 6
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    GOTO L9
+   L8
+    ALOAD 2
+    BIPUSH 7
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+   L10
+    LINENUMBER 27 L10
+    ALOAD 2
+    BIPUSH 8
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    LDC "EQ"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+    GOTO L5
+   L9
+    LINENUMBER 29 L9
+    ALOAD 2
+    BIPUSH 9
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+   L11
+   FRAME SAME
+    LDC "GE"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+   L5
+    LINENUMBER 31 L5
+   FRAME SAME
+    RETURN
+   L12
+    LOCALVARIABLE this LtestData/simple/branches/MyBranchedClass; L0 L12 0
+    LOCALVARIABLE value I L0 L12 1
+    LOCALVARIABLE __$coverage_local$__ [I L0 L12 2
+    MAXSTACK = 4
+    MAXLOCALS = 3
+}

--- a/test-kotlin/test-sources/resources/bytecode/simple/branches/line_indy.txt
+++ b/test-kotlin/test-sources/resources/bytecode/simple/branches/line_indy.txt
@@ -1,0 +1,104 @@
+// access flags 0x31
+public final class testData/simple/branches/MyBranchedClass {
+
+  // compiled from: test.kt
+
+
+  // access flags 0x1
+  public <init>()V
+    INVOKEDYNAMIC __$hits$__()Ljava/lang/Object; [
+      // handle kind 0x6 : INVOKESTATIC
+      com/intellij/rt/coverage/util/IndyUtils.getHitsMask(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "testData.simple.branches.MyBranchedClass"
+    ]
+    CHECKCAST [Z
+    ASTORE 1
+   L0
+    LINENUMBER 22 L0
+    ALOAD 1
+    ICONST_0
+    ICONST_1
+    BASTORE
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+   L1
+    LOCALVARIABLE this LtestData/simple/branches/MyBranchedClass; L0 L1 0
+    LOCALVARIABLE __$coverage_local$__ [Z L0 L1 1
+    MAXSTACK = 3
+    MAXLOCALS = 2
+
+  // access flags 0x11
+  public final foo(I)V
+    INVOKEDYNAMIC __$hits$__()Ljava/lang/Object; [
+      // handle kind 0x6 : INVOKESTATIC
+      com/intellij/rt/coverage/util/IndyUtils.getHitsMask(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "testData.simple.branches.MyBranchedClass"
+    ]
+    CHECKCAST [Z
+    ASTORE 2
+   L0
+    LINENUMBER 24 L0
+    ALOAD 2
+    ICONST_1
+    ICONST_1
+    BASTORE
+    ILOAD 1
+    IFGE L1
+   L2
+    LINENUMBER 25 L2
+    ALOAD 2
+    ICONST_2
+    ICONST_1
+    BASTORE
+    LDC "LE"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+    GOTO L3
+   L1
+    LINENUMBER 26 L1
+    ALOAD 2
+    ICONST_3
+    ICONST_1
+    BASTORE
+   L4
+   FRAME APPEND [[Z]
+    ILOAD 1
+    IFNE L5
+   L6
+    LINENUMBER 27 L6
+    ALOAD 2
+    ICONST_4
+    ICONST_1
+    BASTORE
+    LDC "EQ"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+    GOTO L3
+   L5
+    LINENUMBER 29 L5
+    ALOAD 2
+    ICONST_5
+    ICONST_1
+    BASTORE
+   L7
+   FRAME SAME
+    LDC "GE"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+   L3
+    LINENUMBER 31 L3
+   FRAME SAME
+    RETURN
+   L8
+    LOCALVARIABLE this LtestData/simple/branches/MyBranchedClass; L0 L8 0
+    LOCALVARIABLE value I L0 L8 1
+    LOCALVARIABLE __$coverage_local$__ [Z L0 L8 2
+    MAXSTACK = 3
+    MAXLOCALS = 3
+}

--- a/test-kotlin/test-sources/resources/bytecode/simple/branches/line_indy_with_hits.txt
+++ b/test-kotlin/test-sources/resources/bytecode/simple/branches/line_indy_with_hits.txt
@@ -1,0 +1,122 @@
+// access flags 0x31
+public final class testData/simple/branches/MyBranchedClass {
+
+  // compiled from: test.kt
+
+
+  // access flags 0x1
+  public <init>()V
+    INVOKEDYNAMIC __$hits$__()Ljava/lang/Object; [
+      // handle kind 0x6 : INVOKESTATIC
+      com/intellij/rt/coverage/util/IndyUtils.getHits(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "testData.simple.branches.MyBranchedClass"
+    ]
+    CHECKCAST [I
+    ASTORE 1
+   L0
+    LINENUMBER 22 L0
+    ALOAD 1
+    ICONST_0
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+   L1
+    LOCALVARIABLE this LtestData/simple/branches/MyBranchedClass; L0 L1 0
+    LOCALVARIABLE __$coverage_local$__ [I L0 L1 1
+    MAXSTACK = 4
+    MAXLOCALS = 2
+
+  // access flags 0x11
+  public final foo(I)V
+    INVOKEDYNAMIC __$hits$__()Ljava/lang/Object; [
+      // handle kind 0x6 : INVOKESTATIC
+      com/intellij/rt/coverage/util/IndyUtils.getHits(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "testData.simple.branches.MyBranchedClass"
+    ]
+    CHECKCAST [I
+    ASTORE 2
+   L0
+    LINENUMBER 24 L0
+    ALOAD 2
+    ICONST_1
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    ILOAD 1
+    IFGE L1
+   L2
+    LINENUMBER 25 L2
+    ALOAD 2
+    ICONST_2
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    LDC "LE"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+    GOTO L3
+   L1
+    LINENUMBER 26 L1
+    ALOAD 2
+    ICONST_3
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+   L4
+   FRAME APPEND [[I]
+    ILOAD 1
+    IFNE L5
+   L6
+    LINENUMBER 27 L6
+    ALOAD 2
+    ICONST_4
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+    LDC "EQ"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+    GOTO L3
+   L5
+    LINENUMBER 29 L5
+    ALOAD 2
+    ICONST_5
+    DUP2
+    IALOAD
+    ICONST_1
+    IADD
+    IASTORE
+   L7
+   FRAME SAME
+    LDC "GE"
+    GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
+    SWAP
+    INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/Object;)V
+   L3
+    LINENUMBER 31 L3
+   FRAME SAME
+    RETURN
+   L8
+    LOCALVARIABLE this LtestData/simple/branches/MyBranchedClass; L0 L8 0
+    LOCALVARIABLE value I L0 L8 1
+    LOCALVARIABLE __$coverage_local$__ [I L0 L8 2
+    MAXSTACK = 4
+    MAXLOCALS = 3
+}

--- a/test-kotlin/test-utils/src/com/intellij/rt/coverage/runner.kt
+++ b/test-kotlin/test-utils/src/com/intellij/rt/coverage/runner.kt
@@ -141,7 +141,11 @@ internal fun runWithCoverage(
     mainClass: String = getTestFile(testName).mainClass
 ): ProjectData {
     when (coverage) {
-        Coverage.LINE_FIELD, Coverage.BRANCH_FIELD -> extraArgs.add("-Dcoverage.condy.enable=false")
+        Coverage.LINE_INDY, Coverage.BRANCH_INDY -> extraArgs.add("-Dcoverage.condy.enable=false")
+        Coverage.LINE_FIELD, Coverage.BRANCH_FIELD -> {
+            extraArgs.add("-Dcoverage.condy.enable=false")
+            extraArgs.add("-Dcoverage.indy.enable=false")
+        }
         Coverage.LINE, Coverage.BRANCH -> extraArgs.add("-Didea.new.tracing.coverage=false")
         else -> {}
     }


### PR DESCRIPTION
This adds an additional `CoverageDataAccess` option with an implementation using `INVOKEDYNAMIC`.
It is suitable for class file versions from Java 7 onwards, but from Java 11 onwards the ConDy implementation takes precedence by default. Where possible the new approach takes precedence over the field-based approach.

The principle is very similar to the ConDy approach, where a bootstrap method is invoked to find the correct array, and the result is then cached by the JVM. Unlike the ConDy approach, one lookup is required per method rather than per class, since each individual call-site will use the BSM on first load. The one-time cost is therefore slightly higher, so it makes sense to use ConDy where possible, but the approaches are for the most part equivalent and the JITed assembly is the same for both.
Compared to the field approach, however, the important benefit is that the changes are invisible to the user program. 

My primary motivation for this is to fix various tests in the Kotlin compiler which are currently broken by the field instrumentation approach, e.g. [this one](https://github.com/JetBrains/kotlin/blob/96205cabfdb14a5aa5b1f0127871cee9c09aaef9/compiler/testData/codegen/box/closures/noRefToOuter.kt#L15), but in general it is good to disrupt the user code as little as possible.

